### PR TITLE
Disk performance, Galera graphs: use descriptions

### DIFF
--- a/dashboards/Disk_Performance.json
+++ b/dashboards/Disk_Performance.json
@@ -146,6 +146,7 @@
                     "timeFrom": null, 
                     "timeShift": null, 
                     "title": "Disk Latency", 
+                    "description": "Shows average latency for Reads and Writes IO Devices.  Higher than typical latency for highly loaded storage indicates saturation (overload) and is frequent cause of performance problems.  Higher than normal latency also can indicate internal storage problems.",
                     "tooltip": {
                         "msResolution": false, 
                         "shared": true, 
@@ -248,6 +249,7 @@
                     "timeFrom": null, 
                     "timeShift": null, 
                     "title": "Disk Operations", 
+                    "description": "Shows amount of physical IOs (reads and writes) different devices are serving. Spikes in number of IOs served often corresponds to performance problems due to IO subsystem overload.",
                     "tooltip": {
                         "msResolution": false, 
                         "shared": true, 
@@ -350,6 +352,7 @@
                     "timeFrom": null, 
                     "timeShift": null, 
                     "title": "Disk Bandwidth", 
+                    "description": "Shows volume of reads and writes the storage is handling. This can be better measure of IO capacity usage for network attached and SSD storage as it is often bandwidth limited.  Amount of data being written to the disk can be used to estimate Flash storage life time.",
                     "tooltip": {
                         "msResolution": false, 
                         "shared": true, 
@@ -450,6 +453,7 @@
                     "timeFrom": null, 
                     "timeShift": null, 
                     "title": "Disk Load", 
+                    "description": "Shows how much disk was loaded for reads or writes as average number of outstanding requests at different period of time.  High disk load is a good measure of actual storage utilization. Different storage types handle load differently - some will show latency increases on low loads others can handle higher load with no problems.",
                     "tooltip": {
                         "msResolution": false, 
                         "shared": true, 
@@ -539,6 +543,7 @@
                     "timeFrom": null, 
                     "timeShift": null, 
                     "title": "Disk IO Utilization", 
+                    "description": "Shows disk Utilization as percent of the time when there was at least one IO request in flight. It is designed to match utilization available in iostat tool. It is not very good measure of true IO Capacity Utilization. Consider looking at IO latency and Disk Load Graphs instead.",
                     "tooltip": {
                         "msResolution": false, 
                         "shared": true, 
@@ -639,6 +644,7 @@
                     "timeFrom": null, 
                     "timeShift": null, 
                     "title": "Disk Operations Merge Ratio", 
+                    "description": "Shows how effectively Operating System is able to merge logical IO requests into physical requests.  This is a good measure of the IO locality which can be used for workload characterization.",
                     "tooltip": {
                         "msResolution": false, 
                         "shared": true, 
@@ -742,6 +748,7 @@
                     "timeFrom": null, 
                     "timeShift": null, 
                     "title": "Disk IO Size", 
+                    "description": "Shows average size of a single disk operation.",
                     "tooltip": {
                         "msResolution": false, 
                         "shared": true, 
@@ -781,32 +788,6 @@
             "repeatRowId": null, 
             "showTitle": false, 
             "title": "Disk Stats", 
-            "titleSize": "h6"
-        }, 
-        {
-            "collapse": true, 
-            "height": "250px", 
-            "panels": [
-                {
-                    "content": "Disk Performance Dashboard is designed to provide quick overview of disk IO utilization and performance.\n\n`Disk Latency` - Shows average latency for Reads and Writes IO Devices.  Higher than typical latency for highly loaded storage indicates saturation (overload) and is frequent cause of performance problems.  Higher than normal latency also can indicate internal storage problems.\n\n`Disk Operations` - Shows amount of physical IOs (reads and writes) different devices are serving. Spikes in number of IOs served often corresponds to performance problems due to IO subsystem overload.\n\n`Disk Bandwidth` -  Shows volume of reads and writes the storage is handling. This can be better measure of IO capacity usage for network attached and SSD storage as it is often bandwidth limited.  Amount of data being written to the disk can be used to estimate Flash storage life time.\n\n`Disk Load`  - Shows how much disk was loaded for reads or writes as average number of outstanding requests at different period of time.  High disk load is a good measure of actual storage utilization. Different storage types handle load differently - some will show latency increases on low loads others can handle higher load with no problems.\n\n`Disk IO Utilization` -  Shows disk Utilization as percent of the time when there was at least one IO request in flight. It is designed to match utilization available in iostat tool. It is not very good measure of true IO Capacity Utilization. Consider looking at IO latency and Disk Load Graphs instead.\n\n`Disk Operations Merge Ratio`  -  Shows how effectively Operating System is able to merge logical IO requests into physical requests.  This is a good measure of the IO locality which can be used for workload characterization. \n\n`Disk IO Size`  -  Shows average size of a single disk operation.", 
-                    "datasource": "Prometheus", 
-                    "editable": true, 
-                    "error": false, 
-                    "id": 19, 
-                    "isNew": true, 
-                    "links": [], 
-                    "mode": "markdown", 
-                    "span": 12, 
-                    "style": {}, 
-                    "title": "", 
-                    "type": "text"
-                }
-            ], 
-            "repeat": null, 
-            "repeatIteration": null, 
-            "repeatRowId": null, 
-            "showTitle": true, 
-            "title": "HELP", 
             "titleSize": "h6"
         }
     ], 

--- a/dashboards/PXC_Galera_Graphs.json
+++ b/dashboards/PXC_Galera_Graphs.json
@@ -586,6 +586,7 @@
                     "timeFrom": null, 
                     "timeShift": null, 
                     "title": "Galera Replication Queues", 
+                    "description": "Shows the length of receive and send queues.",
                     "tooltip": {
                         "msResolution": false, 
                         "shared": true, 
@@ -667,6 +668,7 @@
                     "timeFrom": null, 
                     "timeShift": null, 
                     "title": "Galera Cluster Size", 
+                    "description": "Shows the number of members currently connected to the cluster.",
                     "tooltip": {
                         "msResolution": false, 
                         "shared": true, 
@@ -791,6 +793,7 @@
                     "timeFrom": null, 
                     "timeShift": null, 
                     "title": "Galera Flow Control", 
+                    "description": "Shows the number of FC_PAUSE events sent/received. They are sent by a node when its replication queue gets too full. If a node is sending out FC messages it indicates a problem.",
                     "tooltip": {
                         "msResolution": false, 
                         "shared": true, 
@@ -897,6 +900,7 @@
                     "timeFrom": null, 
                     "timeShift": null, 
                     "title": "Galera Parallelization Efficiency", 
+                    "description": "Shows the average distances between highest and lowest seqno that are concurrently applied, committed and can be possibly applied in parallel (potential degree of parallelization).",
                     "tooltip": {
                         "msResolution": false, 
                         "shared": true, 
@@ -1002,6 +1006,7 @@
                     "timeFrom": null, 
                     "timeShift": null, 
                     "title": "Galera Writing Conflicts", 
+                    "description": "Shows the number of local transactions being committed on this node that failed certification (some other node had a commit that conflicted with ours) – client received deadlock error on commit and also the number of local transactions in flight on this node that were aborted because they locked something an applier thread needed – deadlock error anywhere in an open transaction. Spikes in the graph may indicate writing to the same table potentially the same rows from 2 nodes.",
                     "tooltip": {
                         "msResolution": false, 
                         "shared": true, 
@@ -1082,6 +1087,7 @@
                     "timeFrom": null, 
                     "timeShift": null, 
                     "title": "Available Downtime before SST Required", 
+                    "description": "Shows for how long the node can be taken out of the cluster before SST is required. SST is a full state transfer method.",
                     "tooltip": {
                         "msResolution": false, 
                         "shared": true, 
@@ -1187,6 +1193,7 @@
                     "timeFrom": null, 
                     "timeShift": null, 
                     "title": "Galera Writeset Count", 
+                    "description": "Shows the count of transactions received from the cluster (any other node) and replicated to the cluster (from this node).",
                     "tooltip": {
                         "msResolution": false, 
                         "shared": true, 
@@ -1280,6 +1287,7 @@
                     "timeFrom": null, 
                     "timeShift": null, 
                     "title": "Galera Writeset Size", 
+                    "description": "Shows the average transaction size received/replicated.",
                     "tooltip": {
                         "msResolution": false, 
                         "shared": true, 
@@ -1385,6 +1393,7 @@
                     "timeFrom": null, 
                     "timeShift": null, 
                     "title": "Galera Writeset Traffic", 
+                    "description": "Shows the bytes of data received from the cluster (any other node) and replicated to the cluster (from this node).",
                     "tooltip": {
                         "msResolution": false, 
                         "shared": true, 
@@ -1478,6 +1487,7 @@
                     "timeFrom": "24h", 
                     "timeShift": null, 
                     "title": "Galera Network Usage Hourly", 
+                    "description": "Shows the bytes of data received from the cluster (any other node) and replicated to the cluster (from this node).",
                     "tooltip": {
                         "msResolution": false, 
                         "shared": true, 
@@ -1514,31 +1524,6 @@
             "repeatRowId": null, 
             "showTitle": false, 
             "title": "Traffic", 
-            "titleSize": "h6"
-        }, 
-        {
-            "collapse": true, 
-            "height": "250px", 
-            "panels": [
-                {
-                    "content": "`Galera Replication Queues` - Shows the length of receive and send queues.\n\n`Galera Cluster Size` - Shows the number of members currently connected to the cluster.\n\n`Galera Flow Control` - Shows the number of FC_PAUSE events sent/received. They are sent by a node when its replication queue gets too full. If a node is sending out FC messages it indicates the problem.\n\n`Galera Parallelization Efficiency` - Shows the average distances between highest and lowest seqno that are concurrently applied, committed and can be possibly applied in parallel (potential degree of parallelization).\n\n`Galera Writing Conflicts` - Shows the number of local transactions being committed on this node that failed certification (some other node had a commit that conflicted with ours) \u2013 client received deadlock error on commit and also the number of local transactions in flight on this node that were aborted because they locked something an applier thread needed \u2013 deadlock error anywhere in an open transaction. The spikes on the graph may indicate writing to the same table potentially the same rows from 2 nodes.\n\n`Available Downtime before SST Required` - Shows for how long time the node can be taken out of the cluster before SST is required. SST is a full state transfer method.\n\n`Galera Writeset Count` - Shows the count of transactions received from the cluster (any other node) and replicated to the cluster (from this node).\n\n`Galera Writeset Size` - Shows the average transaction size received/replicated.\n\n`Galera Writeset Traffic`, `Galera Network Usage Hourly` - Shows the bytes of data received from the cluster (any other node) and replicated to the cluster (from this node).", 
-                    "datasource": "Prometheus", 
-                    "editable": true, 
-                    "error": false, 
-                    "id": 54, 
-                    "isNew": true, 
-                    "links": [], 
-                    "mode": "markdown", 
-                    "span": 12, 
-                    "title": "", 
-                    "type": "text"
-                }
-            ], 
-            "repeat": null, 
-            "repeatIteration": null, 
-            "repeatRowId": null, 
-            "showTitle": true, 
-            "title": "HELP", 
             "titleSize": "h6"
         }
     ], 


### PR DESCRIPTION
Replace HELP sections at the bottom of the dashboards with widget
descriptions.