### PR TITLE
Use UTC by default in all dashboards.

### DIFF
--- a/dashboards/Amazon_RDS_OS_Metrics.json
+++ b/dashboards/Amazon_RDS_OS_Metrics.json
@@ -1131,7 +1131,7 @@
             "30d"
         ]
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "Amazon RDS OS Metrics",
     "version": 0
 }

--- a/dashboards/Cross_Server_Graphs.json
+++ b/dashboards/Cross_Server_Graphs.json
@@ -815,7 +815,7 @@
         ],
         "type": "timepicker"
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "Cross Server Graphs",
     "version": 0
 }

--- a/dashboards/Disk_Performance.json
+++ b/dashboards/Disk_Performance.json
@@ -939,7 +939,7 @@
         ],
         "type": "timepicker"
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "Disk Performance",
     "version": 0
 }

--- a/dashboards/Disk_Space.json
+++ b/dashboards/Disk_Space.json
@@ -579,7 +579,7 @@
         ],
         "type": "timepicker"
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "Disk Space",
     "version": 0
 }

--- a/dashboards/MariaDB.json
+++ b/dashboards/MariaDB.json
@@ -759,7 +759,7 @@
         ],
         "type": "timepicker"
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "MariaDB",
     "version": 2
 }

--- a/dashboards/MongoDB_Cluster_Summary.json
+++ b/dashboards/MongoDB_Cluster_Summary.json
@@ -1874,7 +1874,7 @@
             "30d"
         ]
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "MongoDB Cluster Summary",
     "version": 0
 }

--- a/dashboards/MongoDB_InMemory.json
+++ b/dashboards/MongoDB_InMemory.json
@@ -1435,7 +1435,7 @@
             "30d"
         ]
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "MongoDB InMemory",
     "version": 0
 }

--- a/dashboards/MongoDB_MMAPv1.json
+++ b/dashboards/MongoDB_MMAPv1.json
@@ -1830,7 +1830,7 @@
             "30d"
         ]
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "MongoDB MMAPv1",
     "version": 0
 }

--- a/dashboards/MongoDB_Overview.json
+++ b/dashboards/MongoDB_Overview.json
@@ -1333,7 +1333,7 @@
             "30d"
         ]
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "MongoDB Overview",
     "version": 0
 }

--- a/dashboards/MongoDB_ReplSet.json
+++ b/dashboards/MongoDB_ReplSet.json
@@ -1897,7 +1897,7 @@
             "30d"
         ]
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "MongoDB ReplSet",
     "version": 0
 }

--- a/dashboards/MongoDB_RocksDB.json
+++ b/dashboards/MongoDB_RocksDB.json
@@ -3103,7 +3103,7 @@
             "30d"
         ]
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "MongoDB RocksDB",
     "version": 0
 }

--- a/dashboards/MongoDB_WiredTiger.json
+++ b/dashboards/MongoDB_WiredTiger.json
@@ -1981,7 +1981,7 @@
             "30d"
         ]
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "MongoDB WiredTiger",
     "version": 0
 }

--- a/dashboards/MySQL_InnoDB_Metrics.json
+++ b/dashboards/MySQL_InnoDB_Metrics.json
@@ -1697,7 +1697,7 @@
         ],
         "type": "timepicker"
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "MySQL InnoDB Metrics",
     "version": 0
 }

--- a/dashboards/MySQL_InnoDB_Metrics_Advanced.json
+++ b/dashboards/MySQL_InnoDB_Metrics_Advanced.json
@@ -2126,7 +2126,7 @@
         ],
         "type": "timepicker"
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "MySQL InnoDB Metrics Advanced",
     "version": 0
 }

--- a/dashboards/MySQL_MyISAM_Metrics.json
+++ b/dashboards/MySQL_MyISAM_Metrics.json
@@ -566,7 +566,7 @@
         ],
         "type": "timepicker"
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "MySQL MyISAM Metrics",
     "version": 0
 }

--- a/dashboards/MySQL_Overview.json
+++ b/dashboards/MySQL_Overview.json
@@ -3916,7 +3916,7 @@
         ],
         "type": "timepicker"
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "MySQL Overview",
     "version": 0
 }

--- a/dashboards/MySQL_Performance_Schema.json
+++ b/dashboards/MySQL_Performance_Schema.json
@@ -755,7 +755,7 @@
         ],
         "type": "timepicker"
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "MySQL Performance Schema",
     "version": 0
 }

--- a/dashboards/MySQL_Query_Response_Time.json
+++ b/dashboards/MySQL_Query_Response_Time.json
@@ -802,7 +802,7 @@
         ],
         "type": "timepicker"
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "MySQL Query Response Time",
     "version": 0
 }

--- a/dashboards/MySQL_Replication.json
+++ b/dashboards/MySQL_Replication.json
@@ -1191,7 +1191,7 @@
         ],
         "type": "timepicker"
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "MySQL Replication",
     "version": 0
 }

--- a/dashboards/MySQL_Table_Statistics.json
+++ b/dashboards/MySQL_Table_Statistics.json
@@ -745,7 +745,7 @@
         ],
         "type": "timepicker"
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "MySQL Table Statistics",
     "version": 0
 }

--- a/dashboards/MySQL_TokuDB_Metrics.json
+++ b/dashboards/MySQL_TokuDB_Metrics.json
@@ -2288,7 +2288,7 @@
             "30d"
         ]
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "MySQL TokuDB Metrics",
     "version": 0
 }

--- a/dashboards/MySQL_User_Statistics.json
+++ b/dashboards/MySQL_User_Statistics.json
@@ -729,7 +729,7 @@
         ],
         "type": "timepicker"
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "MySQL User Statistics",
     "version": 0
 }

--- a/dashboards/PXC_Galera_Cluster_Overview.json
+++ b/dashboards/PXC_Galera_Cluster_Overview.json
@@ -1139,7 +1139,7 @@
         ],
         "type": "timepicker"
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "PXC/Galera Cluster Overview",
     "version": 0
 }

--- a/dashboards/PXC_Galera_Graphs.json
+++ b/dashboards/PXC_Galera_Graphs.json
@@ -1673,7 +1673,7 @@
         ],
         "type": "timepicker"
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "PXC/Galera Graphs",
     "version": 0
 }

--- a/dashboards/Prometheus.json
+++ b/dashboards/Prometheus.json
@@ -979,7 +979,7 @@
             "30d"
         ]
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "Prometheus",
     "version": 0
 }

--- a/dashboards/ProxySQL_Overview.json
+++ b/dashboards/ProxySQL_Overview.json
@@ -990,7 +990,7 @@
         ],
         "type": "timepicker"
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "ProxySQL Overview",
     "version": 0
 }

--- a/dashboards/Summary_Dashboard.json
+++ b/dashboards/Summary_Dashboard.json
@@ -1085,7 +1085,7 @@
         ],
         "type": "timepicker"
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "Summary Dashboard",
     "version": 0
 }

--- a/dashboards/System_Overview.json
+++ b/dashboards/System_Overview.json
@@ -2016,7 +2016,7 @@
         ],
         "type": "timepicker"
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "System Overview",
     "version": 0
 }

--- a/dashboards/Trends_Dashboard.json
+++ b/dashboards/Trends_Dashboard.json
@@ -857,7 +857,7 @@
         ],
         "type": "timepicker"
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "Trends Dashboard",
     "version": 0
 }


### PR DESCRIPTION
This makes things much simpler for teams coordinating across timezones, and is
also more likely to match server log files (which are typically recorded in
UTC).