### PR TITLE
Make sure panel ids in MySQL Overview are unique.

### DIFF
--- a/dashboards/MySQL_Overview.json
+++ b/dashboards/MySQL_Overview.json
@@ -3231,7 +3231,7 @@
                     "error": false,
                     "fill": 2,
                     "grid": {},
-                    "id": 31,
+                    "id": 131,
                     "legend": {
                         "alignAsTable": false,
                         "avg": true,
@@ -3455,7 +3455,7 @@
                     "fill": 6,
                     "grid": {},
                     "height": "",
-                    "id": 2,
+                    "id": 102,
                     "legend": {
                         "alignAsTable": false,
                         "avg": true,
@@ -3755,7 +3755,7 @@
                     "error": false,
                     "fill": 2,
                     "grid": {},
-                    "id": 38,
+                    "id": 138,
                     "legend": {
                         "alignAsTable": false,
                         "avg": true,


### PR DESCRIPTION
Previously "MySQL Connection", "MySQL Select Types" and "MySQL Network Usage Hourly" graphs would not load if "System Charts" were expanded.

This can be replicated by going to https://pmmdemo.percona.com/graph/dashboard/db/mysql-overview?orgId=1, expanding "System Charts" and clicking Refresh in upper right corner. "Panel request cancelled" will be logged in the browser console.

Since I'm not planning to sign the CLA/CCLA you are welcome to close this pull request. Opening a pull request was simply less hassle than creating an account in your JIRA ;)


