### PR TITLE
Update PXC_Galera_Cluster_Overview.json

### DIFF
--- a/dashboards/PXC_Galera_Cluster_Overview.json
+++ b/dashboards/PXC_Galera_Cluster_Overview.json
@@ -285,7 +285,7 @@
                     "calculatedInterval": "2m",
                     "datasourceErrors": {},
                     "errors": {},
-                    "expr": "clamp_max((rate(mysql_global_status_wsrep_flow_control_paused_ns[$interval]) or irate(mysql_global_status_wsrep_flow_control_paused_ns[5m]))/1000000000 * on (instance) group_left mysql_galera_variables_info{wsrep_cluster_name=\"$cluster\"},1)",
+                    "expr": "clamp_max((rate(mysql_global_status_wsrep_flow_control_paused[$interval]) or irate(mysql_global_status_wsrep_flow_control_paused[5m])) * on (instance) group_left mysql_galera_variables_info{wsrep_cluster_name=\"$cluster\"},1)",
                     "format": "time_series",
                     "interval": "$interval",
                     "intervalFactor": 1,


### PR DESCRIPTION
The used metric is wrong for that chart. The chart shows a percentage but the metric gives an absolute time in nanoseconds.
My change uses the correct metric which already reports a percentage. You can verify this in the docs: https://galeracluster.com/library/documentation/monitoring-cluster.html