### PR TITLE
PMM-4690 Fix UI of pmm update.

### DIFF
--- a/pmm-app/src/pmm-update-panel/index.html
+++ b/pmm-app/src/pmm-update-panel/index.html
@@ -113,7 +113,7 @@
             <p>Available version:&nbsp;</p>
             <div class="version">
                 <p>{{nextVersion}} <em>{{newReleaseDate}}</em></p>
-                <a href="{{newsLink}}"
+                <a ng-if="newsLink" href="{{ newsLink }}"
                    class="text-primary pmm-link" target="_blank">What's new?</a>
             </div>
         </div>

--- a/pmm-app/src/pmm-update-panel/modal.html
+++ b/pmm-app/src/pmm-update-panel/modal.html
@@ -38,6 +38,10 @@
         width: 100%;
     }
 
+    #pmm-update-modal .output-collapse {
+        cursor: pointer;
+    }
+
 </style>
 <div class="modal-dialog" role="document" id="pmm-update-modal">
     <div class="modal-content" ng-if="!isUpdated">
@@ -46,15 +50,15 @@
             <h4 ng-if="updateFailed">Update failed</h4>
             <h4 ng-if="updateFailed">{{ errorMessage }}</h4>
             <div class="output-content">
-                <div>
-                    <i class="fa" ng-click="isOutputShown = !isOutputShown"
+                <div class="output-header">
+                    <i class="fa output-collapse" ng-click="isOutputShown = !isOutputShown"
                        ng-class="{'fa-chevron-down': !isOutputShown, 'fa-chevron-up':isOutputShown}"></i>
                     <span>Log</span>
                     <span class="text-secondary text-primary text-right" clipboard-button="output">Copy to clipboard</span>
                 </div>
 
-                <div class="pre-scrollable output-value">
-                    <pre>{{ output }}</pre>
+                <div id="scroll-container" class="pre-scrollable output-value" ng-if="isOutputShown" ng-init="init();">
+                    <pre id="pre-scrollable">{{ output }}</pre>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-4690

- [x] On page load, update widget should call Check API without force parameter. Now it calls it with force=true. Sometimes it calls it twice: first with force=false, then again with force=true.
- [x] Sometimes update button spins on the page load, and doesn't stop.
- [x] It shows "What's new?" link even when backend does not return latest_news_url URL. (Backend does not currently return latest_news_url, but it will).
- [x] Log "^" button doesn't seem to do anything.
- [x] The log does not auto-scroll. It should.
- [x] "PMM has been successfully upgraded to version" contains old version in the end.
- [x] Use location.reload(true) to skip cache.