### PR TITLE
PMM-5517 Add missed dashboards to README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,30 +3,28 @@
 This is a set of Grafana dashboards for database and system monitoring using Prometheus datasource.
  
  
+ * Amazon RDS / Aurora MySQL metrics (CloudWatch datasource)
+ * Advanced Data Exploration
  * Compare System Parameters
  * CPU Utilization Details (Cores)
- * Disk Performance
- * Disk Space
- * Network Overview
- * NUMA Overview
- * System Overview
- * Amazon RDS / Aurora MySQL metrics (CloudWatch datasource)
  * Cross Server Graphs
  * Disk Performance
  * Disk Space
+ * Home Dashboard
  * MongoDB Cluster Summary
+ * MongoDB InMemory
+ * MongoDB MMAPv1
  * MongoDB Overview
  * MongoDB ReplSet
  * MongoDB RocksDB
  * MongoDB WiredTiger
- * MongoDB MMAPv1
- * MongoDB InMemory
  * MySQL Amazon Aurora Metrics
- * MySQL MyRocks Metrics
+ * MySQL Command Handler Counters Compare
  * MySQL InnoDB Metrics
  * MySQL InnoDB Metrics Advanced
  * MySQL InnoDB Compression
  * MySQL MyISAM/Aria Metrics
+ * MySQL MyRocks Metrics
  * MySQL Overview
  * MySQL Performance Schema
  * MySQL Performance Schema Wait Event Analyses
@@ -35,18 +33,17 @@ This is a set of Grafana dashboards for database and system monitoring using Pro
  * MySQL Table Statistics
  * MySQL TokuDB Metrics
  * MySQL User Statistics
- * MySQL Command Handler Counters Compare
+ * Network Overview
+ * NUMA Overview
  * PostgreSQL Overview
  * ProxySQL Overview
- * PXC/Galera Cluster Overview
- * PXC/Galera Graphs
- * Advanced Data Exploration
- * Cross Server Graphs
- * Home Dashboard
  * Prometheus
  * Prometheus Exporter Status
  * Prometheus Exporters Overview
+ * PXC/Galera Cluster Overview
+ * PXC/Galera Graphs
  * Summary Dashboard
+ * System Overview
  * Trends Dashboard
  * _PMM Add Instance
  * _PMM Amazon RDS and Remote Instances

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 This is a set of Grafana dashboards for database and system monitoring using Prometheus datasource.
  
  
- * Amazon RDS / Aurora MySQL metrics (CloudWatch datasource)
  * Advanced Data Exploration
+ * Amazon RDS / Aurora MySQL metrics (CloudWatch datasource)
  * Compare System Parameters
  * CPU Utilization Details (Cores)
  * Cross Server Graphs
@@ -49,6 +49,8 @@ This is a set of Grafana dashboards for database and system monitoring using Pro
  * _PMM Amazon RDS and Remote Instances
  * _PMM Query Analytics Settings
  * _PMM System Summary
+
+
 
 These dashboards are also a part of [Percona Monitoring and Management](https://www.percona.com/doc/percona-monitoring-and-management/index.html) project.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ This is a set of Grafana dashboards for database and system monitoring using Pro
  * Prometheus Exporters Overview
  * Summary Dashboard
  * Trends Dashboard
- 
  * _PMM Add Instance
  * _PMM Amazon RDS and Remote Instances
  * _PMM Query Analytics Settings

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 ## Grafana dashboards for MySQL and MongoDB monitoring using Prometheus [![Build Status](https://travis-ci.org/percona/grafana-dashboards.svg?branch=master)](https://travis-ci.org/percona/grafana-dashboards)[![CLA assistant](https://cla-assistant.percona.com/readme/badge/percona/grafana-dashboards)](https://cla-assistant.percona.com/percona/grafana-dashboards)
 
 This is a set of Grafana dashboards for database and system monitoring using Prometheus datasource.
-
- * Amazon RDS OS metrics (CloudWatch datasource)
+ 
+ 
+ * Compare System Parameters
+ * CPU Utilization Details (Cores)
+ * Disk Performance
+ * Disk Space
+ * Network Overview
+ * NUMA Overview
+ * System Overview
+ * Amazon RDS / Aurora MySQL metrics (CloudWatch datasource)
  * Cross Server Graphs
  * Disk Performance
  * Disk Space
@@ -13,25 +21,38 @@ This is a set of Grafana dashboards for database and system monitoring using Pro
  * MongoDB WiredTiger
  * MongoDB MMAPv1
  * MongoDB InMemory
+ * MySQL Amazon Aurora Metrics
+ * MySQL MyRocks Metrics
  * MySQL InnoDB Metrics
  * MySQL InnoDB Metrics Advanced
  * MySQL InnoDB Compression
  * MySQL MyISAM/Aria Metrics
  * MySQL Overview
  * MySQL Performance Schema
+ * MySQL Performance Schema Wait Event Analyses
  * MySQL Query Response Time
  * MySQL Replication
  * MySQL Table Statistics
- * MySQL TokuDB Graphs
+ * MySQL TokuDB Metrics
  * MySQL User Statistics
  * MySQL Command Handler Counters Compare
+ * PostgreSQL Overview
+ * ProxySQL Overview
  * PXC/Galera Cluster Overview
  * PXC/Galera Graphs
+ * Advanced Data Exploration
+ * Cross Server Graphs
+ * Home Dashboard
  * Prometheus
- * ProxySQL Overview
+ * Prometheus Exporter Status
+ * Prometheus Exporters Overview
  * Summary Dashboard
- * System Overview
  * Trends Dashboard
+ 
+ * _PMM Add Instance
+ * _PMM Amazon RDS and Remote Instances
+ * _PMM Query Analytics Settings
+ * _PMM System Summary
 
 These dashboards are also a part of [Percona Monitoring and Management](https://www.percona.com/doc/percona-monitoring-and-management/index.html) project.
 


### PR DESCRIPTION
Added the missing set of Grafana dashboards in the list provided by Percona for database and system monitoring using Prometheus datasource.

I installed on my system and found out there were more dashboards provided then Listed, thought of adding in the list. 