### PR TITLE
PMM-5058 CONTRIBUTING.md Travis-CI replacement by Jenkins

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ make
 
     Example: from dbazhenov:PMM-5053_dbazhenov_tooltip to percona:PMM-2.0
 
-10.    Your Pull Request must pass three tests: Codacy, Travis-CI, and Contributor License Agreement.
+10.    Your Pull Request must pass three tests: Codacy, Jenkins CI, and Contributor License Agreement.
 
     You need to open the Contributor License Agreement page, read it, and confirm it. 
 


### PR DESCRIPTION
This is a simple Pull Request necessary for this article. Since Travis has been replaced by Jenkins.