### PR TITLE
SAAS-122 fix refresh button margins

### DIFF
--- a/pmm-app/src/pmm-check/CheckPanel.tsx
+++ b/pmm-app/src/pmm-check/CheckPanel.tsx
@@ -47,22 +47,11 @@ export class CheckPanel extends PureComponent<CheckPanelProps, CheckPanelState> 
 
   render() {
     const {
-      width,
-      height,
       options: { title },
     } = this.props;
 
     return (
-      <div
-        id="antd"
-        className="check-panel"
-        data-qa="db-check-panel"
-        style={{
-          position: 'relative',
-          width,
-          height,
-        }}
-      >
+      <div id="antd" className="check-panel" data-qa="db-check-panel">
         <div className={styles.PanelWrapper}>
           <div className={styles.TitleBar}>
             <div className={styles.Title}>{title || 'Failed Checks'}</div>


### PR DESCRIPTION
This PR removes the size params passed from Grafana to the panel.
Not that I like it, since it's not removing the root cause, but that fixes the rendering problem for both the table and the button.

https://github.com/Percona-Lab/pmm-submodules/pull/829