### PR TITLE
Update mongodb_connections metrics name

### DIFF
--- a/dashboards/MongoDB_Overview.json
+++ b/dashboards/MongoDB_Overview.json
@@ -321,7 +321,7 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "mongodb_mongod_connections{instance=~\"$host\", state=\"current\"} or\nmongodb_mongos_connections{instance=~\"$host\", state=\"current\"}",
+                    "expr": "mongodb_connections{instance=~\"$host\", state=\"current\"} or\nmongodb_mongos_connections{instance=~\"$host\", state=\"current\"}",
                     "format": "time_series",
                     "hide": false,
                     "interval": "$interval",
@@ -1485,7 +1485,7 @@
                 "multiFormat": "glob",
                 "name": "host",
                 "options": [],
-                "query": "label_values({__name__=~\"mongodb_mongod_connections{cluster=~\\\"$cluster\\\"}|mongodb_up\"}, instance)",
+                "query": "label_values({__name__=~\"mongodb_connections{cluster=~\\\"$cluster\\\"}|mongodb_up\"}, instance)",
                 "refresh": 2,
                 "regex": "",
                 "sort": 1,


### PR DESCRIPTION
These metric names are valid for bitnami/mongodb-exporter:0.11.0