### PR TITLE
PMM-6191 Fix Prometheus Process CPU Usage formulas (#800)

### DIFF
--- a/dashboards/Prometheus.json
+++ b/dashboards/Prometheus.json
@@ -833,7 +833,7 @@
                             "step": 60
                         },
                         {
-                            "expr": "count(avg by (service_name) (node_cpu_seconds_total{mode=\"user\", node_name=\"pmm-server\"}))",
+                            "expr": "count(node_cpu_seconds_total{mode=\"user\", node_name=\"pmm-server\"})",
                             "format": "time_series",
                             "interval": "$interval",
                             "intervalFactor": 1,
@@ -842,7 +842,7 @@
                             "step": 40
                         },
                         {
-                            "expr": "count(avg by (service_name) (node_cpu_seconds_total{mode=\"user\", node_name=\"pmm-server\"}))*0.75",
+                            "expr": "count(node_cpu_seconds_total{mode=\"user\", node_name=\"pmm-server\"})*0.75",
                             "format": "time_series",
                             "interval": "$interval",
                             "intervalFactor": 1,


### PR DESCRIPTION
[![PMM-6191](https://badgen.net/badge/JIRA/PMM-6191/green)](https://jira.percona.com/browse/PMM-6191)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* Fix: count cpu metrics

CPU Count Total and Limit should be using avg; count will return the correct value, avg will return a wrong value.

* PMM-6191 Fix Prometheus Process CPU Usage formulas

Co-authored-by: Vadim Yalovets <vadim.yalovets@percona.com>