### PR TITLE
PMM-6455 Fixing False positives and changing tests to Nightly 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,7 +91,7 @@ pipeline {
             parallel {
                 stage('e2e tests') {
                     options {
-                        timeout(time: 5, unit: "MINUTES")
+                        timeout(time: 10, unit: "MINUTES")
                     }
                     steps {
                         sh """

--- a/pmm-app/pr.codecept.js
+++ b/pmm-app/pr.codecept.js
@@ -50,7 +50,7 @@ exports.config = {
   },
   multiple: {
     parallel: {
-      chunks: 4,
+      chunks: 3,
       browsers: ['chromium'],
     },
   },

--- a/pmm-app/tests/QAN/steps/qanActions.js
+++ b/pmm-app/tests/QAN/steps/qanActions.js
@@ -418,6 +418,7 @@ module.exports = {
   },
 
   async getCountOfItems() {
+    I.waitForInvisible(qanPage.elements.spinner, 30);
     const resultsCount = (await I.grabTextFrom(qanPage.fields.countOfItems)).split(' ');
 
     return resultsCount[2];

--- a/pmm-app/tests/pages/dashboardPage.js
+++ b/pmm-app/tests/pages/dashboardPage.js
@@ -113,7 +113,7 @@ module.exports = {
     ],
   },
   nodeSummaryDashboard: {
-    url: 'graph/d/node-instance-summary/node-summary?orgId=1&refresh=1m&from=now-15m&to=now',
+    url: 'graph/d/node-instance-summary/node-summary?orgId=1&refresh=1m&from=now-30m&to=now',
     metrics: [
       'System Uptime',
       'Virtual CPUs',

--- a/pmm-app/tests/pages/pmmSettingsPage.js
+++ b/pmm-app/tests/pages/pmmSettingsPage.js
@@ -152,6 +152,8 @@ module.exports = {
 
   async verifySelectedResolution(resolution) {
     const selector = `${this.fields.metricsResolution + resolution}"]`;
+    
+    I.waitForElement(selector, 30);
     const className = await I.grabAttributeFrom(selector, 'class');
 
     assert.equal(className.includes('active'), true, 'Metric resolution should be active');

--- a/pmm-app/tests/verifyAWSRDSMySQLInstance_test.js
+++ b/pmm-app/tests/verifyAWSRDSMySQLInstance_test.js
@@ -63,7 +63,7 @@ Scenario(
 );
 
 Scenario(
-  'Verify MySQL Instances Overview Dashboard contains AWS RDS MySQL 5.6 filters @not-pr-pipeline',
+  'Verify MySQL Instances Overview Dashboard contains AWS RDS MySQL 5.6 filters @not-ui-pipeline @nightly @not-pr-pipeline',
   async (I, dashboardPage, remoteInstancesPage) => {
     const filters = remoteInstancesPage.rds;
 

--- a/pmm-app/tests/verifyAWSRDSMySQLInstance_test.js
+++ b/pmm-app/tests/verifyAWSRDSMySQLInstance_test.js
@@ -5,7 +5,7 @@ Before(async (I) => {
 });
 
 Scenario(
-  'PMM-T138 Verify disabling enhanced metrics for RDS, PMM-T139 Verify disabling basic metrics for RDS, PMM-T9 Verify adding RDS instances [critical] @not-pr-pipeline',
+  'PMM-T138 Verify disabling enhanced metrics for RDS, PMM-T139 Verify disabling basic metrics for RDS, PMM-T9 Verify adding RDS instances [critical] @not-ui-pipeline @nightly @not-pr-pipeline',
   async (I, remoteInstancesPage, pmmInventoryPage) => {
     const instanceIdToMonitor = remoteInstancesPage.rds['Service Name'];
 
@@ -24,7 +24,7 @@ Scenario(
 );
 
 Scenario(
-  'Verify AWS RDS MySQL 5.6 instance has status running [critical] @pmm-post-update @not-pr-pipeline',
+  'Verify AWS RDS MySQL 5.6 instance has status running [critical] @not-ui-pipeline @nightly @pmm-post-update @not-pr-pipeline',
   async (I, remoteInstancesPage, pmmInventoryPage) => {
     const serviceName = remoteInstancesPage.rds['Service Name'];
 
@@ -35,7 +35,7 @@ Scenario(
 );
 // Skipping the tests because QAN does not get any data right after instance was added for monitoring
 xScenario(
-  'Verify QAN Filters contain AWS RDS MySQL 5.6 after it was added for monitoring @not-pr-pipeline',
+  'Verify QAN Filters contain AWS RDS MySQL 5.6 after it was added for monitoring @not-ui-pipeline @nightly @not-pr-pipeline',
   async (I, qanPage, remoteInstancesPage) => {
     const filters = remoteInstancesPage.rds;
 
@@ -52,7 +52,7 @@ xScenario(
 );
 
 Scenario(
-  'Verify MySQL Instances Overview Dashboard for AWS RDS MySQL 5.6 data after it was added for monitoring @not-pr-pipeline',
+  'Verify MySQL Instances Overview Dashboard for AWS RDS MySQL 5.6 data after it was added for monitoring @not-ui-pipeline @nightly @not-pr-pipeline',
   async (I, dashboardPage) => {
     I.amOnPage(dashboardPage.mySQLInstanceOverview.urlWithRDSFilter);
     dashboardPage.waitForDashboardOpened();

--- a/pmm-app/tests/verifyAWSRDSMySQLInstance_test.js
+++ b/pmm-app/tests/verifyAWSRDSMySQLInstance_test.js
@@ -58,7 +58,7 @@ Scenario(
     dashboardPage.waitForDashboardOpened();
     await dashboardPage.expandEachDashboardRow();
     await dashboardPage.verifyThereAreNoGraphsWithNA();
-    await dashboardPage.verifyThereAreNoGraphsWithoutData(2);
+    await dashboardPage.verifyThereAreNoGraphsWithoutData(3);
   }
 );
 

--- a/pmm-app/tests/verifyInsightDashboards_test.js
+++ b/pmm-app/tests/verifyInsightDashboards_test.js
@@ -17,7 +17,7 @@ Scenario(
 );
 
 Scenario(
-  'Open Prometheus Dashboard and verify Metrics are present and graphs are displayed @not-pr-pipeline',
+  'Open Prometheus Dashboard and verify Metrics are present and graphs are displayed @not-ui-pipeline @nightly @not-pr-pipeline',
   async (I, adminPage, dashboardPage) => {
     I.amOnPage(dashboardPage.prometheusDashboard.url);
     dashboardPage.waitForDashboardOpened();
@@ -30,7 +30,7 @@ Scenario(
 
 Scenario(
   // eslint-disable-next-line max-len
-  'Open the Prometheus Exporters Status Dashboard and verify Metrics are present and graphs are displayed @not-pr-pipeline',
+  'Open the Prometheus Exporters Status Dashboard and verify Metrics are present and graphs are displayed @not-ui-pipeline @nightly @not-pr-pipeline',
   async (I, dashboardPage, adminPage) => {
     I.amOnPage(dashboardPage.prometheusExporterStatusDashboard.url);
     dashboardPage.waitForDashboardOpened();
@@ -47,7 +47,7 @@ Scenario(
 //Need to Skip to avoid false positive, investigate and fix
 xScenario(
   // eslint-disable-next-line max-len
-  'Open the Prometheus Exporters Overview Dashboard and verify Metrics are present and graphs are displayed @not-pr-pipeline',
+  'Open the Prometheus Exporters Overview Dashboard and verify Metrics are present and graphs are displayed @not-ui-pipeline @nightly @not-pr-pipeline',
   async (I, dashboardPage, adminPage) => {
     I.amOnPage(dashboardPage.prometheusExporterOverviewDashboard.url);
     dashboardPage.waitForDashboardOpened();

--- a/pmm-app/tests/verifyMongodbDashboards_test.js
+++ b/pmm-app/tests/verifyMongodbDashboards_test.js
@@ -5,7 +5,7 @@ Before(async (I) => {
 });
 
 Scenario(
-  'Open the MongoDB Instance Summary Dashboard and verify Metrics are present and graphs are displayed @not-pr-pipeline',
+  'Open the MongoDB Instance Summary Dashboard and verify Metrics are present and graphs are displayed @not-ui-pipeline @nightly @not-pr-pipeline',
   async (I, dashboardPage) => {
     I.amOnPage(dashboardPage.mongodbOverviewDashboard.url);
     dashboardPage.waitForDashboardOpened();
@@ -17,7 +17,7 @@ Scenario(
 );
 
 Scenario(
-  'Open the MongoDB Cluster Summary Dashboard and verify Metrics are present and graphs are displayed @not-pr-pipeline',
+  'Open the MongoDB Cluster Summary Dashboard and verify Metrics are present and graphs are displayed @not-ui-pipeline @nightly @not-pr-pipeline',
   async (I, adminPage, dashboardPage) => {
     I.amOnPage(dashboardPage.mongoDbClusterSummaryDashboard.url);
     dashboardPage.waitForDashboardOpened();

--- a/pmm-app/tests/verifyOSDashboards_test.js
+++ b/pmm-app/tests/verifyOSDashboards_test.js
@@ -5,7 +5,7 @@ Before(async (I) => {
 });
 
 Scenario(
-  'Open the Node Summary Dashboard and verify Metrics are present and graphs are displayed @not-pr-pipeline',
+  'Open the Node Summary Dashboard and verify Metrics are present and graphs are displayed @not-ui-pipeline @nightly @not-pr-pipeline',
   async (I, dashboardPage, adminPage) => {
     I.amOnPage(dashboardPage.nodeSummaryDashboard.url);
     dashboardPage.waitForDashboardOpened();
@@ -19,7 +19,7 @@ Scenario(
 );
 
 Scenario(
-  'Open the Nodes Compare Dashboard and verify Metrics are present and graphs are displayed @not-pr-pipeline',
+  'Open the Nodes Compare Dashboard and verify Metrics are present and graphs are displayed @not-ui-pipeline @nightly @not-pr-pipeline',
   async (I, dashboardPage) => {
     I.amOnPage(dashboardPage.nodesCompareDashboard.url);
     dashboardPage.waitForDashboardOpened();
@@ -31,7 +31,7 @@ Scenario(
 );
 
 Scenario(
-  'PMM-T165: Verify Annotation with Default Options @not-pr-pipeline',
+  'PMM-T165: Verify Annotation with Default Options @not-ui-pipeline @nightly @not-pr-pipeline',
   async (I, dashboardPage) => {
     const annotationTitle = 'pmm-annotate-without-tags';
 
@@ -44,7 +44,7 @@ Scenario(
 
 //Need to skip to avoid failure, investigate and fix it soon
 xScenario(
-  'PMM-T166: Verify adding annotation with specified tags @not-pr-pipeline',
+  'PMM-T166: Verify adding annotation with specified tags @not-ui-pipeline @nightly @not-pr-pipeline',
   async (I, dashboardPage) => {
     const annotationTitle2 = 'pmm-annotate-tags';
     const annotationTag1 = 'pmm-testing-tag1';

--- a/pmm-app/tests/verifyOSDashboards_test.js
+++ b/pmm-app/tests/verifyOSDashboards_test.js
@@ -42,8 +42,7 @@ Scenario(
   }
 );
 
-//Need to skip to avoid failure, investigate and fix it soon
-xScenario(
+Scenario(
   'PMM-T166: Verify adding annotation with specified tags @not-ui-pipeline @nightly @not-pr-pipeline',
   async (I, dashboardPage) => {
     const annotationTitle2 = 'pmm-annotate-tags';


### PR DESCRIPTION
[![PMM-6455](https://badgen.net/badge/JIRA/PMM-6455/green)](https://jira.percona.com/browse/PMM-6455)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This will allow monitor Dashboard related tests to be run with Nightly Run along with QAN, and Regular UI tests that are stable and not resource hungry will run on Regular FB and server Autobuild.

It also updates the chunk value to 3, because thats more practical then having one browser run ideal and not have any tests to run

Increases default timeout for PR-pipeline to 10 mins, to avoid build abort issues. 