### PR TITLE
SAAS-252 removed unused method

### DIFF
--- a/pmm-app/tests/QAN/steps/qanActions.js
+++ b/pmm-app/tests/QAN/steps/qanActions.js
@@ -17,11 +17,6 @@ module.exports = {
     }
   },
 
-  waitForQANPageLoaded() {
-    I.waitForVisible(qanPage.fields.table, 30);
-    I.waitForClickable(qanPage.fields.nextPageNavigation, 30);
-  },
-
   changeGroupBy(groupBy = 'Client Host') {
     I.waitForElement(qanPage.fields.groupBySelector, 30);
     I.forceClick(qanPage.fields.groupBySelector);


### PR DESCRIPTION
[![SAAS-252](https://badgen.net/badge/JIRA/SAAS-252/green)](https://jira.percona.com/browse/SAAS-252)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

almost nothing to do regarding this ticket, waitForClickable methods were cleaned up during other tickets development