### PR TITLE
PMM-7224: Fix Postgres Instances Overview selectors

### DIFF
--- a/dashboards/PostgreSQL_Instances_Overview.json
+++ b/dashboards/PostgreSQL_Instances_Overview.json
@@ -9445,6 +9445,7 @@
                 "useTags": false
             },
             {
+                "allFormat": "glob",
                 "allValue": null,
                 "current": {},
                 "datasource": "Metrics",
@@ -9467,7 +9468,8 @@
                 "useTags": false
             },
             {
-                "allValue": ".*",
+                "allFormat": "glob",
+                "allValue": null,
                 "current": {},
                 "datasource": "Metrics",
                 "definition": "label_values(pg_up{node_name=~\"$node_name\",environment=~\"$environment\"}, service_name)",


### PR DESCRIPTION
https://github.com/Percona-Lab/pmm-submodules/pull/1723

What this PR does / why we need it: Postgres Instances Overview selectors were not working properly, namely "Environment", "Node name" and "Service"
Which issue(s) this PR fixes: https://jira.percona.com/browse/PMM-7224