### PR TITLE
PMM-7982: increase sort icon's right position

### DIFF
--- a/pmm-app/src/pmm-qan/panel/components/Overview/components/QanTable/Table.styles.ts
+++ b/pmm-app/src/pmm-qan/panel/components/Overview/components/QanTable/Table.styles.ts
@@ -134,7 +134,7 @@ export const getStyles = stylesFactory((theme: GrafanaTheme) => {
         content: '';
         display: block;
         height: 0;
-        right: 5px;
+        right: 13px;
         top: 50%;
         position: absolute;
         width: 0;


### PR DESCRIPTION
What this PR does / why we need it: the sort icons on QAN are too close to the right, making it harder to click when there's the scrollbar there.

Which issue(s) this PR fixes: https://jira.percona.com/browse/PMM-7982