### PR TITLE
PMM-6451 Fix passing parameters between QAN and dashboards

### DIFF
--- a/pmm-app/src/pmm-qan/panel/QueryAnalytics.constants.ts
+++ b/pmm-app/src/pmm-qan/panel/QueryAnalytics.constants.ts
@@ -8,6 +8,8 @@ enum PageSizes {
   high = '100',
 }
 
+export const ALL_VARIABLE_TEXT = 'All';
+export const AUTO_VARIABLE_TEXT = 'auto';
 export const PAGE_SIZE_OPTIONS = [PageSizes.low, PageSizes.medium, PageSizes.high];
 export const DEFAULT_PAGE_NUMBER = 1;
 export const DEFAULT_PAGE_SIZE = +PageSizes.low;

--- a/pmm-app/src/pmm-qan/panel/QueryAnalytics.tools.ts
+++ b/pmm-app/src/pmm-qan/panel/QueryAnalytics.tools.ts
@@ -1,7 +1,9 @@
+import { ALL_VARIABLE_TEXT } from './QueryAnalytics.constants';
+
 export const getLabelQueryParams = (labels) => Object.keys(labels)
   .filter((key) => key !== 'interval')
   .map((key) => ({
     key,
     value: labels[key],
   }))
-  .filter((item) => item.value.filter((element) => element !== 'All').length) || [];
+  .filter((item) => item.value.filter((element) => element !== ALL_VARIABLE_TEXT).length) || [];


### PR DESCRIPTION
- Use default values for filters when they are empty to prevent errors in QAN calling the API with empty values
- Remove 'All' filter from URL when another filter is selected

https://github.com/Percona-Lab/pmm-submodules/pull/1768