### PR TITLE
PMM-9027 Fix MongoDB replication lag graph aggregation

### DIFF
--- a/dashboards/MongoDB_ReplSet_Summary.json
+++ b/dashboards/MongoDB_ReplSet_Summary.json
@@ -859,15 +859,15 @@
             "steppedLine": false,
             "targets": [
                 {
-                    "expr": "avg by (service_name) (max(max_over_time(mongodb_mongod_replset_member_replication_lag{set=\"$replset\",service_name=~\"$secondary\"}[$interval]) > 0) by (service_name,set) or max(max_over_time(mongodb_mongod_replset_member_replication_lag{set=\"$replset\",service_name=~\"$secondary\"}[5m]) > 0) by (service_name,set))",
+                    "expr": "avg by (name) (max(max_over_time(mongodb_mongod_replset_member_replication_lag{set=\"$replset\",service_name=~\"$secondary\"}[$interval]) > 0) by (name,set) or max(max_over_time(mongodb_mongod_replset_member_replication_lag{set=\"$replset\",service_name=~\"$secondary\"}[5m]) > 0) by (name,set))",
                     "interval": "$interval",
                     "intervalFactor": 1,
-                    "legendFormat": "{{service_name}}",
+                    "legendFormat": "{{name}}",
                     "refId": "A",
                     "step": 300
                 },
                 {
-                    "expr": "avg by (set) (max(max_over_time(mongodb_mongod_replset_member_replication_lag{set=\"$replset\",service_name=~\"$secondary\"}[$interval]) > 0) by (service_name,set) or max(max_over_time(mongodb_mongod_replset_member_replication_lag{set=\"$replset\",service_name=~\"$secondary\"}[5m]) > 0) by (service_name,set))",
+                    "expr": "avg by (set) (max(max_over_time(mongodb_mongod_replset_member_replication_lag{set=\"$replset\",service_name=~\"$secondary\"}[$interval]) > 0) by (name,set) or max(max_over_time(mongodb_mongod_replset_member_replication_lag{set=\"$replset\",service_name=~\"$secondary\"}[5m]) > 0) by (name,set))",
                     "hide": true,
                     "interval": "$interval",
                     "legendFormat": "Avg",


### PR DESCRIPTION
The previous aggregation showed same max replication lag value for all replicas in the set, taking the largest value across all replicas. With switching the aggregation filter from service_name to name, the graph should correctly show the lag value for each replica set member.