### PR TITLE
Update convert-dash-from-PMM.py

### DIFF
--- a/misc/convert-dash-from-PMM.py
+++ b/misc/convert-dash-from-PMM.py
@@ -1,6 +1,6 @@
 ##############################################################################################################
 # This script converts a PMM dashboard so it can be used in an external Prometheus + Grafana installation. 
-# It doesn`t need any input from you. It replaces PMM2 labels (node_name, service_name) 
+# It doesn't need any input from you. It replaces PMM2 labels (node_name, service_name) 
 # used in variables with default labels (instance).
 #
 ##############################################################################################################

--- a/misc/convert-dash-from-PMM.py
+++ b/misc/convert-dash-from-PMM.py
@@ -1,6 +1,6 @@
 ##############################################################################################################
 # This script converts a PMM dashboard so it can be used in an external Prometheus + Grafana installation. 
-# It doesn’t need any input from you. It replaces PMM2 labels (node_name, service_name) 
+# It doesn`t need any input from you. It replaces PMM2 labels (node_name, service_name) 
 # used in variables with default labels (instance).
 #
 ##############################################################################################################


### PR DESCRIPTION
The current version of the file misc/convert-dash-from-PMM.py contains a non-ASCII 

character '\xe2' and does not run without modification.  A user cloning the grafana-dashboards repo needs to either replace this character (line 3) or declare an encoding before the script can be run.