### PR TITLE
fix convert from PMM bug with query in query

### DIFF
--- a/misc/convert-dash-from-PMM.py
+++ b/misc/convert-dash-from-PMM.py
@@ -105,18 +105,23 @@ def check_formulas(dashboard, currentVariableName, newVariableName):
             for list_index, lists in enumerate(dashboard['templating']['list']):
                     if 'query' in lists.keys():
                         expr = dashboard['templating']['list'][list_index]['query']
-                        expr = re.sub('node_type=~\"[a-z,$_|]*\"', '', expr)
+                        # i don't know why but some dashboards have a query element with a query element
+                        # so we need to check that query is a string and not an object
+                        if isinstance(expr, str):
+                            expr = re.sub('node_type=~\"[a-z,$_|]*\"', '', expr)
+                            if expr.find(currentVariableName) != -1:    # check if variable is used in an expression
+                                print (' <<<< %s' % (expr,)) 
+                                dashboard['templating']['list'][list_index]['query'] = expr.replace(currentVariableName, newVariableName)
+                                dashboard['templating']['list'][list_index]['definition'] = expr.replace(currentVariableName, newVariableName)
+                                print (' >>>> %s\n' % (dashboard['templating']['list'][list_index]['query'],))
+
                         name = dashboard['templating']['list'][list_index]['name']
-                        name = re.sub('node_type=~\"[a-z,$_|]*\"', '', name)
-                        if expr.find(currentVariableName) != -1:    # check if variable is used in an expression
-                            print (' <<<< %s' % (expr,)) 
-                            dashboard['templating']['list'][list_index]['query'] = expr.replace(currentVariableName, newVariableName)
-                            dashboard['templating']['list'][list_index]['definition'] = expr.replace(currentVariableName, newVariableName)
-                            print (' >>>> %s\n' % (dashboard['templating']['list'][list_index]['query'],))
-                        if name.find(currentVariableName) != -1:    # check if variable is used in an expression
-                            print (' <<<< %s' % (name,)) 
-                            dashboard['templating']['list'][list_index]['name'] = newVariableName
-                            print (' >>>> %s\n' % (dashboard['templating']['list'][list_index]['name'],))
+                        if isinstance(name, str):
+                            name = re.sub('node_type=~\"[a-z,$_|]*\"', '', name)
+                            if name.find(currentVariableName) != -1:    # check if variable is used in an expression
+                                print (' <<<< %s' % (name,)) 
+                                dashboard['templating']['list'][list_index]['name'] = newVariableName
+                                print (' >>>> %s\n' % (dashboard['templating']['list'][list_index]['name'],))
     return dashboard
 
 


### PR DESCRIPTION
some dashboards have a query element in a query element and then the convert stops the python error:
(with e.g. dashboards/MySQL/MySQL_Performance_Schema_Details.json)
```
Traceback (most recent call last):
  File "misc/convert-dash-from-PMM.py", line 198, in <module>
    main()
  File "misc/convert-dash-from-PMM.py", line 179, in main
    check_formulas(dashboard, "service_name", "instance")
  File "misc/convert-dash-from-PMM.py", line 130, in check_formulas
    expr = re.sub('node_type=~\"[a-z,$_|]*\"', '', expr)
  File "...Python3.framework/Versions/3.8/lib/python3.8/re.py", line 208, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: expected string or bytes-like object
```