### PR TITLE
PMM-7 fix dashboard path

### DIFF
--- a/pmm-app/src/plugin.json
+++ b/pmm-app/src/plugin.json
@@ -239,7 +239,7 @@
     {
       "type": "dashboard",
       "name": "MySQL Instances Compare",
-      "path": "dashboards/MongoDB/MySQL_Instances_Compare.json"
+      "path": "dashboards/MySQL/MySQL_Instances_Compare.json"
     },
     {
       "type": "dashboard",


### PR DESCRIPTION
It's a very small fix for the dashboard path. We have an error in the log:
```
t=2021-12-17T13:48:53+0000 lvl=info msg=Profiler logger=plugins.backend pluginId=alexanderzobnin-zabbix-datasource enabled=false
t=2021-12-17T13:48:54+0000 lvl=eror msg="Failed to load app dashboards" logger=plugins error="open /srv/grafana/plugins/pmm-app/dist/dashboards/MongoDB/MySQL_Instances_Compare.json: no such file or directory"
```
It doesn't impact user experience but it's an error anyway.