### PR TITLE
PMM-9234-QAN-fix-isHistogramAvailable: add groupBy

### DIFF
--- a/pmm-app/src/pmm-qan/panel/components/Details/Details.tsx
+++ b/pmm-app/src/pmm-qan/panel/components/Details/Details.tsx
@@ -70,6 +70,7 @@ export const DetailsSection: FC = () => {
       component: (
         <Metrics
           databaseType={databaseType}
+          groupBy={groupBy}
           totals={totals}
           metrics={metrics}
           textMetrics={textMetrics}

--- a/pmm-app/src/pmm-qan/panel/components/Details/Metrics/Metrics.tsx
+++ b/pmm-app/src/pmm-qan/panel/components/Details/Metrics/Metrics.tsx
@@ -159,7 +159,7 @@ const Metrics: FC<MetricsProps> = ({
         <Table columns={columns} data={metrics} loading={loading} noData={null} />
       </Collapse>
       {showHistogram && (
-        <div ref={histogramRef} className={styles.histogramWrapper}>
+        <div ref={histogramRef} data-testid="histogram-collapse-container" className={styles.histogramWrapper}>
           <Collapse
             collapsible
             label={MetricsTabs.histogram}

--- a/pmm-app/src/pmm-qan/panel/components/Details/Metrics/Metrics.tsx
+++ b/pmm-app/src/pmm-qan/panel/components/Details/Metrics/Metrics.tsx
@@ -17,11 +17,11 @@ import { useHistogram } from './hooks/useHistogram';
 import { TopQuery } from '../TopQuery/TopQuery';
 
 const Metrics: FC<MetricsProps> = ({
-  databaseType, totals, metrics, textMetrics = {}, loading,
+  databaseType, totals, metrics, textMetrics = {}, loading, groupBy,
 }) => {
   const theme = useTheme();
   const styles = getStyles(theme);
-  const isHistogramAvailable = databaseType === Databases.postgresql && !totals;
+  const isHistogramAvailable = databaseType === Databases.postgresql && !totals && groupBy === 'queryid';
   const [histogramData, histogramLoading] = useHistogram(theme, isHistogramAvailable);
   const [isDistributionPanelOpen, setDistributionPanelVisibility] = useState(true);
   const [isMetricsPanelOpen, setMetricsPanelVisibility] = useState(true);

--- a/pmm-app/src/pmm-qan/panel/components/Details/Metrics/Metrics.types.ts
+++ b/pmm-app/src/pmm-qan/panel/components/Details/Metrics/Metrics.types.ts
@@ -1,4 +1,5 @@
 import { DatabasesType } from '../Details.types';
+import { QueryDimension } from '../../../provider/provider.types';
 
 export interface MetricsProps {
   databaseType: DatabasesType;
@@ -6,6 +7,7 @@ export interface MetricsProps {
   textMetrics?: TextMetrics;
   totals: boolean;
   loading: boolean;
+  groupBy: QueryDimension;
 }
 
 export interface HistogramRequest {


### PR DESCRIPTION
fixing the Internal server error in some cases when grouping by User Name/Database is used in QAN
https://jira.percona.com/browse/PMM-9234