### PR TITLE
PMM-9828-QAN-default-filters-search-redirecting: fix redirecting

### DIFF
--- a/pmm-app/src/pmm-qan/panel/provider/provider.tools.ts
+++ b/pmm-app/src/pmm-qan/panel/provider/provider.tools.ts
@@ -39,6 +39,7 @@ interface GrafanaVariables {
   details_tab?: string;
   [key: string]: any;
   dimensionSearchText?: string;
+  search?: string;
 }
 export const refreshGrafanaVariables = (state) => {
   const {
@@ -122,6 +123,10 @@ export const refreshGrafanaVariables = (state) => {
 
   if (state.openDetailsTab) {
     variablesQuery.details_tab = state.openDetailsTab;
+  }
+
+  if (state.search) {
+    variablesQuery.search = state.search;
   }
 
   getLocationSrv().update({

--- a/pmm-app/src/pmm-qan/panel/provider/provider.tsx
+++ b/pmm-app/src/pmm-qan/panel/provider/provider.tsx
@@ -175,6 +175,7 @@ export const UrlParametersProvider = ({ timeRange, children }) => {
         from: newFrom,
         to: newTo,
       },
+      search: query.get('search'),
     };
 
     if (from === newFrom && to === newTo) {

--- a/pmm-app/src/pmm-qan/panel/provider/provider.tsx
+++ b/pmm-app/src/pmm-qan/panel/provider/provider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { omit, isEqual } from 'lodash';
 import { parseURL, refreshGrafanaVariables, setLabels } from './provider.tools';
 import { QueryAnalyticsContext } from './provider.types';
@@ -134,6 +134,7 @@ export const UrlParametersProvider = ({ timeRange, children }) => {
   };
 
   const query = new URLSearchParams(window.location.search);
+  const searchRef = useRef<string| null>(null);
 
   const [panelState, setContext] = useState({
     ...parseURL(query),
@@ -141,7 +142,16 @@ export const UrlParametersProvider = ({ timeRange, children }) => {
       from: timeRange.raw.from,
       to: timeRange.raw.to,
     },
+    search: searchRef.current,
   });
+
+  if (searchRef.current !== query.get('search')) {
+    searchRef.current = query.get('search');
+    setContext({
+      ...panelState,
+      search: searchRef.current,
+    });
+  }
 
   useEffect(() => {
     setContext({
@@ -175,7 +185,7 @@ export const UrlParametersProvider = ({ timeRange, children }) => {
         from: newFrom,
         to: newTo,
       },
-      search: query.get('search'),
+      search: searchRef.current,
     };
 
     if (from === newFrom && to === newTo) {


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-9828
PR to fix the reset of the search page in QAN. Previously, when going to the search page by the link in the navigation, default filters were installed and the key parameter search=open was overwritten, resulting in a redirect to the QAN home page.

https://user-images.githubusercontent.com/90199600/164713356-b4409167-4f0f-4301-be4e-0b7dd79cf247.mp4