### PR TITLE
PMM-10330 fix volume mapping for plugin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ services:
       - ENABLE_BACKUP_MANAGEMENT=1
       - ENABLE_ALERTING=1
     volumes:
-      - ./dist:/var/lib/grafana/plugins/pmm-app/dist
+      - ./dist:/srv/grafana/plugins/pmm-app/dist
     ports:
       - 80:80
     restart: always

--- a/pmm-app/docker-compose.yaml
+++ b/pmm-app/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     container_name: pmm-server
     image: perconalab/pmm-server:dev-latest
     volumes:
-      - "./dist:/var/lib/grafana/plugins/pmm-app/dist"
+      - "./dist:/srv/grafana/plugins/pmm-app/dist"
     ports:
       - 80:80
       - 443:443


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-10330

As describe in the issue the plugin path is `/srv/grafana/plugins` and not `/var/lib/grafana/plugins` like specified by the contributing guideline.

So I changed it from the `CONTRIBUTING.md` and the `docker-compose.yaml`