### PR TITLE
PMM-9398 Error for InnoDB Log Buffer Usage metric dashboard

### DIFF
--- a/dashboards/MySQL/MySQL_InnoDB_Details.json
+++ b/dashboards/MySQL/MySQL_InnoDB_Details.json
@@ -13446,7 +13446,7 @@
               "step": 300
             },
             {
-              "expr": "avg by (service_name) (max_over_time((mysql_global_status_innodb_lsn_current{service_name=~\"$service_name\"}-mysql_global_status_innodb_lsn_flushed{service_name=~\"$service_name\"})[$interval:1s]))",
+              "expr": "avg by (service_name) (max_over_time((mysql_global_status_innodb_lsn_current{service_name=~\"$service_name\"}-mysql_global_status_innodb_lsn_flushed{service_name=~\"$service_name\"})[$interval]))",
               "format": "time_series",
               "interval": "$interval",
               "intervalFactor": 1,


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-9398

Removing the sampling for Max Log Space Used at 1s as this breaks the rendering with too many points

- https://github.com/Percona-Lab/pmm-submodules/pull/2672