### PR TITLE
PMM-10483 Allow QAN refresh retrigger

### DIFF
--- a/pmm-app/src/pmm-qan/panel/provider/provider.tsx
+++ b/pmm-app/src/pmm-qan/panel/provider/provider.tsx
@@ -183,17 +183,14 @@ export const UrlParametersProvider = ({ timeRange, children }) => {
   const [previousState, setPreviousState] = useState(panelState);
 
   useEffect(() => {
-    const newFrom = getAbsoluteTime(timeRange.raw.from);
     const newTo = getAbsoluteTime(timeRange.raw.to);
 
-    if (!((from === newFrom) && (to === newTo))) {
-      if (newTo === 'now') {
-        setToTimeMomentValue(timeRange.to.utc().subtract(1, 'minute').format('YYYY-MM-DDTHH:mm:ssZ'));
-        setFromTimeMomentValue(timeRange.from.utc().subtract(1, 'minute').format('YYYY-MM-DDTHH:mm:ssZ'));
-      } else {
-        setToTimeMomentValue(timeRange.to.utc().format('YYYY-MM-DDTHH:mm:ssZ'));
-        setFromTimeMomentValue(timeRange.from.utc().format('YYYY-MM-DDTHH:mm:ssZ'));
-      }
+    if (newTo === 'now') {
+      setToTimeMomentValue(timeRange.to.utc().subtract(1, 'minute').format('YYYY-MM-DDTHH:mm:ssZ'));
+      setFromTimeMomentValue(timeRange.from.utc().subtract(1, 'minute').format('YYYY-MM-DDTHH:mm:ssZ'));
+    } else {
+      setToTimeMomentValue(timeRange.to.utc().format('YYYY-MM-DDTHH:mm:ssZ'));
+      setFromTimeMomentValue(timeRange.from.utc().format('YYYY-MM-DDTHH:mm:ssZ'));
     }
   }, [timeRange, from, to]);
 


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-10483

Allow refreshing time range values event if they haven't changed.

Disallowing in would prevent the trigger of the state update which in
turn wouldn't trigger grafana variables refresh and a new api call.