### PR TITLE
PMM-10692-add-links-high-cpu-panel

### DIFF
--- a/dashboards/Experimental/New_Home_Dashboard.json
+++ b/dashboards/Experimental/New_Home_Dashboard.json
@@ -1365,6 +1365,13 @@
           "color": {
             "mode": "thresholds"
           },
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "Node summary ${__field.labels.node_name}",
+              "url": "/graph/d/node-instance-overview/nodes-overview?$__url_time_range&var-node_name=${__field.labels.node_name}"
+            }
+          ],
           "mappings": [],
           "noValue": "No CPU anomalies",
           "thresholds": {
@@ -1375,7 +1382,7 @@
                 "value": null
               },
               {
-                "color": "dark-red",
+                "color": "red",
                 "value": 1
               }
             ]
@@ -1503,9 +1510,16 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
+            "fixedColor": "red",
+            "mode": "thresholds"
           },
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "Disk details ${__field.labels.node_name}",
+              "url": "/graph/d/node-disk/disk-details?$__url_time_range&var-node_name=${__field.labels.node_name}"
+            }
+          ],
           "mappings": [],
           "noValue": "No disk queue anomalies",
           "thresholds": {
@@ -1517,7 +1531,7 @@
               },
               {
                 "color": "red",
-                "value": 90
+                "value": 30
               }
             ]
           },

--- a/dashboards/Experimental/New_Home_Dashboard.json
+++ b/dashboards/Experimental/New_Home_Dashboard.json
@@ -50,7 +50,7 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1663158485008,
+  "iteration": 1663243892974,
   "links": [
     {
       "asDropdown": false,
@@ -1433,6 +1433,13 @@
             "mode": "thresholds"
           },
           "displayName": "${__series.name}",
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "Node summary ${__field.labels.node_name}",
+              "url": "/graph/d/node-instance-overview/nodes-overview?$__url_time_range&var-node_name=${__field.labels.node_name}"
+            }
+          ],
           "mappings": [],
           "max": 100,
           "min": 90,
@@ -1566,6 +1573,14 @@
           "color": {
             "mode": "thresholds"
           },
+          "displayName": "${__field.labels.node_name}",
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "Disk details ${__field.labels.node_name}",
+              "url": "/graph/d/node-disk/disk-details?$__url_time_range&var-node_name=${__field.labels.node_name}"
+            }
+          ],
           "mappings": [],
           "max": 200,
           "min": 20,


### PR DESCRIPTION
[PMM-10692](https://jira.percona.com/browse/PMM-10692) Added links for panels with specific predefined node_name. From High CPU Servers and CPU Anomalies to Nodes Overview dashboard, from High Disk Queue and Disk Queue Anomalies to Disk Details dashboard.
![изображение](https://user-images.githubusercontent.com/83747830/190585009-ee14f054-7b1b-47b0-8822-86a57eab30ee.png)
![изображение](https://user-images.githubusercontent.com/83747830/190585721-e0d87d06-5b8b-4f43-bbb9-62a91dc1bf58.png)
