### PR TITLE
PMM-11298 Change query for CPU busy VictoriaMetrics dashboard

### DIFF
--- a/dashboards/Insight/VictoriaMetrics.json
+++ b/dashboards/Insight/VictoriaMetrics.json
@@ -3570,7 +3570,7 @@
       "pluginVersion": "8.3.5",
       "targets": [
         {
-          "expr": "clamp_max(avg by (instance) (sum by (mode) ( (clamp_max(rate(node_cpu_seconds_total{node_name=\"pmm-server\",mode!='idle',mode!=\"iowait\"}[$interval]),1)) or  (clamp_max(irate(node_cpu_seconds_total{node_name=\"pmm-server\",mode!='idle',mode!=\"iowait\"}[5m]),1)) )),1) *100",
+          "expr": "max(clamp_max(sum by () (avg by (mode)((clamp_max(rate(node_cpu_seconds_total{node_name=~\"pmm-server\",mode!=\"idle\",mode!=\"iowait\",mode!=\"steal\"}[$interval]),1)))*100),100))",
           "interval": "$interval",
           "legendFormat": "",
           "refId": "A"


### PR DESCRIPTION
PMM-11298 Changed query for "CPU Busy" panel in VictoriaMetrics dashboard.

Was:

![изображение](https://user-images.githubusercontent.com/83747830/209818602-a30b664a-eb35-4668-aa70-5ebe9f0d7179.png)

Now:

![изображение](https://user-images.githubusercontent.com/83747830/209818788-ec4e9710-b0d9-4a0f-95a0-e881f3cf9cd4.png)

