### PR TITLE
PMM-11762 Bump grafana version to 9.2.13

### DIFF
--- a/pmm-app/package.json
+++ b/pmm-app/package.json
@@ -34,9 +34,9 @@
   "dependencies": {
     "@ant-design/icons": "^4.0.6",
     "@emotion/css": "^11.7.1",
-    "@grafana/data": "9.2.5",
-    "@grafana/runtime": "9.2.5",
-    "@grafana/ui": "9.2.5",
+    "@grafana/data": "9.2.13",
+    "@grafana/runtime": "9.2.13",
+    "@grafana/ui": "9.2.13",
     "@testing-library/jest-dom": "5.11.5",
     "@testing-library/react": "11.1.2",
     "@testing-library/react-hooks": "^3.2.1",
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@babel/preset-env": "^7.9.5",
-    "@grafana/toolkit": "9.2.5",
+    "@grafana/toolkit": "9.2.13",
     "@types/enzyme": "^3.10.5",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/grafana": "https://git@github.com/CorpGlory/types-grafana.git",

--- a/pmm-app/yarn.lock
+++ b/pmm-app/yarn.lock
@@ -1668,13 +1668,13 @@
     ua-parser-js "^1.0.2"
     web-vitals "^2.1.4"
 
-"@grafana/data@9.2.5":
-  version "9.2.5"
-  resolved "https://registry.yarnpkg.com/@grafana/data/-/data-9.2.5.tgz#f30764e68496d0a668d16ca782409c69db86a44d"
-  integrity sha512-ZNv+rVJ7oqOhb3M+5l26whTxPEHZq9+TbEH4dBgHtpBh/CQXMnqnnq0F7JdL6hDapoN/VUiMoPHCNNhjA351aQ==
+"@grafana/data@9.2.13":
+  version "9.2.13"
+  resolved "https://registry.yarnpkg.com/@grafana/data/-/data-9.2.13.tgz#da241101e3909e228621ce8bfb18c540a7b7be1e"
+  integrity sha512-EOXBlQxTIX+/xEiSxPso4t4CpXoZ/AFloefhtF4gNcYCHL4NF0ctF8nyxCBFtNhpG6ltluWcUn4qLPokkYzRfQ==
   dependencies:
     "@braintree/sanitize-url" "6.0.0"
-    "@grafana/schema" "9.2.5"
+    "@grafana/schema" "9.2.13"
     "@types/d3-interpolate" "^1.4.0"
     d3-interpolate "1.4.0"
     date-fns "2.29.1"
@@ -1694,10 +1694,10 @@
     uplot "1.6.22"
     xss "1.0.13"
 
-"@grafana/e2e-selectors@9.2.5":
-  version "9.2.5"
-  resolved "https://registry.yarnpkg.com/@grafana/e2e-selectors/-/e2e-selectors-9.2.5.tgz#f1b55d7eb047fde76d6818966be6671ed53a31e6"
-  integrity sha512-SdUFwl6R+pZ3b5WgYbfBX8U1tj1yyBhjpQgbLaL3bVkLI8hjEsKSMbsUdoKaQM3Frv1SBOn0GOIvDaf4K1BL+A==
+"@grafana/e2e-selectors@9.2.13":
+  version "9.2.13"
+  resolved "https://registry.yarnpkg.com/@grafana/e2e-selectors/-/e2e-selectors-9.2.13.tgz#86ee38f5e752324bca144f74d975362cba84d264"
+  integrity sha512-0xTkAcPEIvZL9kbB8gsn5AyTpzbYfuLH5ZfTJNAbWlr92RClOpwkzRk8gbf1i1E2vOG6yWLUyGu0Bgegd1EXaw==
   dependencies:
     "@grafana/tsconfig" "^1.2.0-rc1"
     tslib "2.4.0"
@@ -1717,15 +1717,15 @@
     eslint-plugin-react-hooks "4.3.0"
     typescript "4.6.4"
 
-"@grafana/runtime@9.2.5":
-  version "9.2.5"
-  resolved "https://registry.yarnpkg.com/@grafana/runtime/-/runtime-9.2.5.tgz#f3eb5bc9227edf4b3f2366ab09d3b77067937d6a"
-  integrity sha512-vbQ1OVuuPeyLXuU1JS/tqUxfv7yLuejw0tDn587E+L2/FYM7F4jvN1FkoVh1NSLNQEpyQCow1a4VHDsBVqVsZg==
+"@grafana/runtime@9.2.13":
+  version "9.2.13"
+  resolved "https://registry.yarnpkg.com/@grafana/runtime/-/runtime-9.2.13.tgz#c2caf37d4dec93631b272e4b0c9e25341c678df2"
+  integrity sha512-G5dvZlUheWdbXdHv1r3ZPXlpQGwSYSs1KxJBrVBInT6ll/JBsAouemvG82sleDSsUjG+/KIJAemazapeZqSuXA==
   dependencies:
     "@grafana/agent-web" "^0.4.0"
-    "@grafana/data" "9.2.5"
-    "@grafana/e2e-selectors" "9.2.5"
-    "@grafana/ui" "9.2.5"
+    "@grafana/data" "9.2.13"
+    "@grafana/e2e-selectors" "9.2.13"
+    "@grafana/ui" "9.2.13"
     "@sentry/browser" "6.19.7"
     history "4.10.1"
     lodash "4.17.21"
@@ -1733,17 +1733,17 @@
     systemjs "0.20.19"
     tslib "2.4.0"
 
-"@grafana/schema@9.2.5":
-  version "9.2.5"
-  resolved "https://registry.yarnpkg.com/@grafana/schema/-/schema-9.2.5.tgz#72cdbeb5670345c452474c69fbb09c07329dbb82"
-  integrity sha512-hZSpFSXJ5zj7mIQDNzgkFOBGcM9QkT1P3wfn2Z1GIUHI7lzN+b/edBCEkFcj/ZkDwg9gRxpEGuZ3+lrt+uI4vQ==
+"@grafana/schema@9.2.13":
+  version "9.2.13"
+  resolved "https://registry.yarnpkg.com/@grafana/schema/-/schema-9.2.13.tgz#737c97f33cc0f4ea5164812ead59b4d4a6f936ea"
+  integrity sha512-zyIiyVfJd9UqpP7gpGRXFqGzKlb8YFlo3SHeftODJog1OwhVoTTejimhSfYI8tWOHDIRy3SVmskDQG38ItQRYg==
   dependencies:
     tslib "2.4.0"
 
-"@grafana/toolkit@9.2.5":
-  version "9.2.5"
-  resolved "https://registry.yarnpkg.com/@grafana/toolkit/-/toolkit-9.2.5.tgz#89e9a759d35f54d21ddfa6aef8e83e0d4eca1116"
-  integrity sha512-n86YIoRi7oVQ7MzJqeNoap2m6IBL4qJM3JVcQ+gmRmZgLnSp5a5OXMkTzCh5AAYPoU+/zpiuFONM8dVZS89dkg==
+"@grafana/toolkit@9.2.13":
+  version "9.2.13"
+  resolved "https://registry.yarnpkg.com/@grafana/toolkit/-/toolkit-9.2.13.tgz#ecc08a194f15e5a0df9fe49f449893984ca0a15c"
+  integrity sha512-rq/MNFPbV2cQyqNQLKjEN9dVYnvPjy79weXM4sWQU9D377a0BXNzTbfcj5a5OG+NP5G6ddKyWGtJJoZ/WZxH3A==
   dependencies:
     "@babel/core" "7.18.9"
     "@babel/plugin-proposal-class-properties" "7.18.6"
@@ -1757,10 +1757,10 @@
     "@babel/preset-env" "7.18.9"
     "@babel/preset-react" "7.18.6"
     "@babel/preset-typescript" "7.18.6"
-    "@grafana/data" "9.2.5"
+    "@grafana/data" "9.2.13"
     "@grafana/eslint-config" "5.0.0"
     "@grafana/tsconfig" "^1.2.0-rc1"
-    "@grafana/ui" "9.2.5"
+    "@grafana/ui" "9.2.13"
     "@jest/core" "27.5.1"
     "@types/command-exists" "^1.2.0"
     "@types/eslint" "8.4.1"
@@ -1835,16 +1835,16 @@
   resolved "https://registry.yarnpkg.com/@grafana/tsconfig/-/tsconfig-1.2.0-rc1.tgz#10973c978ec95b0ea637511254b5f478bce04de7"
   integrity sha512-+SgQeBQ1pT6D/E3/dEdADqTrlgdIGuexUZ8EU+8KxQFKUeFeU7/3z/ayI2q/wpJ/Kr6WxBBNlrST6aOKia19Ag==
 
-"@grafana/ui@9.2.5":
-  version "9.2.5"
-  resolved "https://registry.yarnpkg.com/@grafana/ui/-/ui-9.2.5.tgz#03388bf7bee1b3b34261fab7c04378cd4896cc0b"
-  integrity sha512-o8gWdPUx4+VMDMReEWC47qpa2R61SZb/5nlwU7jruCLA7KQNJjAOwQj7euI3iL1OW7y80gI+IG8pR+RTQc1lIg==
+"@grafana/ui@9.2.13":
+  version "9.2.13"
+  resolved "https://registry.yarnpkg.com/@grafana/ui/-/ui-9.2.13.tgz#44c6b125826cd586c362f532761acd3ffe6cefca"
+  integrity sha512-8m3MTqBzAuDRSp3E/UNZ5elvL4N49OVF4Do1otOdqLtkA4oQ8pICDQrDm2G7Ywnx27BG9fkAiYSSFa1IRRHcBw==
   dependencies:
     "@emotion/css" "11.9.0"
     "@emotion/react" "11.9.3"
-    "@grafana/data" "9.2.5"
-    "@grafana/e2e-selectors" "9.2.5"
-    "@grafana/schema" "9.2.5"
+    "@grafana/data" "9.2.13"
+    "@grafana/e2e-selectors" "9.2.13"
+    "@grafana/schema" "9.2.13"
     "@monaco-editor/react" "4.4.5"
     "@popperjs/core" "2.11.5"
     "@react-aria/button" "3.6.1"


### PR DESCRIPTION
Bump grafana to version 9.2.13.

PMM-11762

FB: https://github.com/Percona-Lab/pmm-submodules/pull/3128