### PR TITLE
PMM-11904 Changed broken queries after VictoriaMetrics upgrade

### DIFF
--- a/dashboards/Insight/VictoriaMetrics.json
+++ b/dashboards/Insight/VictoriaMetrics.json
@@ -610,7 +610,7 @@
       "pluginVersion": "8.3.5",
       "targets": [
         {
-          "expr": "sum(vm_rows{job=\"$job\", instance=~\"$instance\", type=\"indexdb\"})",
+          "expr": "sum(vm_rows{job=\"$job\", instance=~\"$instance\", type=~\"indexdb.*\"})",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -691,7 +691,7 @@
       "pluginVersion": "8.3.5",
       "targets": [
         {
-          "expr": "sum(vm_concurrent_addrows_current{job=\"$job\", instance=\"$instance\"})/ sum(vm_concurrent_addrows_capacity{job=\"$job\", instance=\"$instance\"})",
+          "expr": "sum(vm_concurrent_insert_current{job=\"$job\", instance=\"$instance\"})/sum(vm_concurrent_insert_capacity{job=\"$job\", instance=\"$instance\"})",
           "format": "time_series",
           "instant": false,
           "interval": "$interval",


### PR DESCRIPTION
PMM-11904 Fix "Index Size" panel and "Concurrent Inserts" due by changed metrics name and labels.