### PR TITLE
PMM-11746 Removed thresholds for Top InnoDB I/O reads and writes panels

### DIFF
--- a/dashboards/MySQL/MySQL_Instances_Overview.json
+++ b/dashboards/MySQL/MySQL_Instances_Overview.json
@@ -2478,16 +2478,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "#37872D",
+                "color": "dark-blue",
                 "value": null
-              },
-              {
-                "color": "rgba(237, 129, 40, 0.89)",
-                "value": 0.6
-              },
-              {
-                "color": "rgba(245, 54, 54, 0.9)",
-                "value": 0.9
               }
             ]
           },
@@ -2622,8 +2614,16 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "dark-blue",
+                "color": "#37872D",
                 "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 0.6
+              },
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": 0.9
               }
             ]
           },

--- a/dashboards/MySQL/MySQL_Instances_Overview.json
+++ b/dashboards/MySQL/MySQL_Instances_Overview.json
@@ -2554,16 +2554,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "#37872D",
+                "color": "dark-blue",
                 "value": null
-              },
-              {
-                "color": "rgba(237, 129, 40, 0.89)",
-                "value": 0.6
-              },
-              {
-                "color": "rgba(245, 54, 54, 0.9)",
-                "value": 0.9
               }
             ]
           },
@@ -2630,16 +2622,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "#37872D",
+                "color": "dark-blue",
                 "value": null
-              },
-              {
-                "color": "rgba(237, 129, 40, 0.89)",
-                "value": 0.6
-              },
-              {
-                "color": "rgba(245, 54, 54, 0.9)",
-                "value": 0.9
               }
             ]
           },


### PR DESCRIPTION
PMM-11746 Changed colors from green/orange/red to blue for read/write panels:

![изображение](https://user-images.githubusercontent.com/83747830/232010020-37c21a82-7be0-4b88-b8ba-4af275b6aa64.png)

New:

![изображение](https://user-images.githubusercontent.com/83747830/232009622-98a17a10-34d9-4dce-b018-cee782efb380.png)
