### PR TITLE
PMM-11692 Changed name and colors for query

### DIFF
--- a/dashboards/MySQL/MySQL_Instances_Overview.json
+++ b/dashboards/MySQL/MySQL_Instances_Overview.json
@@ -782,16 +782,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "#37872D",
+                "color": "dark-blue",
                 "value": null
-              },
-              {
-                "color": "rgba(237, 129, 40, 0.89)",
-                "value": 0.5
-              },
-              {
-                "color": "rgba(245, 54, 54, 0.9)",
-                "value": 0.8
               }
             ]
           },
@@ -844,7 +836,7 @@
           "step": 300
         }
       ],
-      "title": "Top MySQL Active Client Threads",
+      "title": "Top MySQL Idle Client Threads",
       "type": "stat"
     },
     {


### PR DESCRIPTION
PMM-11692 Removed thresholds for Top MySQL Active Client Threads panel, removed colors. Changed name to "Top MySQL Idle Client".

Old:

![изображение](https://user-images.githubusercontent.com/83747830/232034426-3b98cbce-5045-4de5-9d4d-3cbbfd67e955.png)

New:

![изображение](https://user-images.githubusercontent.com/83747830/232034544-cc1776a7-b123-45d2-8537-18aec1f444ef.png)
