### PR TITLE
PMM-12114 Bump grafana version to 9.2.18

### DIFF
--- a/pmm-app/package.json
+++ b/pmm-app/package.json
@@ -34,9 +34,9 @@
   "dependencies": {
     "@ant-design/icons": "^4.0.6",
     "@emotion/css": "^11.7.1",
-    "@grafana/data": "9.2.13",
-    "@grafana/runtime": "9.2.13",
-    "@grafana/ui": "9.2.13",
+    "@grafana/data": "9.2.18",
+    "@grafana/runtime": "9.2.18",
+    "@grafana/ui": "9.2.18",
     "@testing-library/jest-dom": "5.11.5",
     "@testing-library/react": "11.1.2",
     "@testing-library/react-hooks": "^3.2.1",
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@babel/preset-env": "^7.9.5",
-    "@grafana/toolkit": "9.2.13",
+    "@grafana/toolkit": "9.2.18",
     "@types/enzyme": "^3.10.5",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/grafana": "https://git@github.com/CorpGlory/types-grafana.git",

--- a/pmm-app/yarn.lock
+++ b/pmm-app/yarn.lock
@@ -1668,13 +1668,13 @@
     ua-parser-js "^1.0.2"
     web-vitals "^2.1.4"
 
-"@grafana/data@9.2.13":
-  version "9.2.13"
-  resolved "https://registry.yarnpkg.com/@grafana/data/-/data-9.2.13.tgz#da241101e3909e228621ce8bfb18c540a7b7be1e"
-  integrity sha512-EOXBlQxTIX+/xEiSxPso4t4CpXoZ/AFloefhtF4gNcYCHL4NF0ctF8nyxCBFtNhpG6ltluWcUn4qLPokkYzRfQ==
+"@grafana/data@9.2.18":
+  version "9.2.18"
+  resolved "https://registry.yarnpkg.com/@grafana/data/-/data-9.2.18.tgz#1afc85f908ab4702585222d258905b9e509ecebd"
+  integrity sha512-60JZN0DTl0RtZG17qcD3P8QH+roHhdX5WPDcnXgJjWB6ufFA7hAFh933rgIyu6btX78u8UX4JeriGQ0DF5irfg==
   dependencies:
     "@braintree/sanitize-url" "6.0.0"
-    "@grafana/schema" "9.2.13"
+    "@grafana/schema" "9.2.18"
     "@types/d3-interpolate" "^1.4.0"
     d3-interpolate "1.4.0"
     date-fns "2.29.1"
@@ -1694,10 +1694,10 @@
     uplot "1.6.22"
     xss "1.0.13"
 
-"@grafana/e2e-selectors@9.2.13":
-  version "9.2.13"
-  resolved "https://registry.yarnpkg.com/@grafana/e2e-selectors/-/e2e-selectors-9.2.13.tgz#86ee38f5e752324bca144f74d975362cba84d264"
-  integrity sha512-0xTkAcPEIvZL9kbB8gsn5AyTpzbYfuLH5ZfTJNAbWlr92RClOpwkzRk8gbf1i1E2vOG6yWLUyGu0Bgegd1EXaw==
+"@grafana/e2e-selectors@9.2.18":
+  version "9.2.18"
+  resolved "https://registry.yarnpkg.com/@grafana/e2e-selectors/-/e2e-selectors-9.2.18.tgz#6c9513e0b25af3449dfbfbd14db3781d02015c4b"
+  integrity sha512-dzcroDyasyaDRirhKQ+ufRq2M9Ow0BP/eO7Wu3zkb4O4lkwlZ7w1HTQRrF12s0sGS+zOQ4Ee4flt2f5F34NK8w==
   dependencies:
     "@grafana/tsconfig" "^1.2.0-rc1"
     tslib "2.4.0"
@@ -1717,15 +1717,15 @@
     eslint-plugin-react-hooks "4.3.0"
     typescript "4.6.4"
 
-"@grafana/runtime@9.2.13":
-  version "9.2.13"
-  resolved "https://registry.yarnpkg.com/@grafana/runtime/-/runtime-9.2.13.tgz#c2caf37d4dec93631b272e4b0c9e25341c678df2"
-  integrity sha512-G5dvZlUheWdbXdHv1r3ZPXlpQGwSYSs1KxJBrVBInT6ll/JBsAouemvG82sleDSsUjG+/KIJAemazapeZqSuXA==
+"@grafana/runtime@9.2.18":
+  version "9.2.18"
+  resolved "https://registry.yarnpkg.com/@grafana/runtime/-/runtime-9.2.18.tgz#fecdfa7764471c58c8f73c2ed90be0e2228b816f"
+  integrity sha512-xBpjsMU2Uc8coyazTlHYFvYMWCqRSMLykyP5/zdQvatlR1Hr644B0MlIy3FC386kvNjotHHf5kMf+pBxjLW9/Q==
   dependencies:
     "@grafana/agent-web" "^0.4.0"
-    "@grafana/data" "9.2.13"
-    "@grafana/e2e-selectors" "9.2.13"
-    "@grafana/ui" "9.2.13"
+    "@grafana/data" "9.2.18"
+    "@grafana/e2e-selectors" "9.2.18"
+    "@grafana/ui" "9.2.18"
     "@sentry/browser" "6.19.7"
     history "4.10.1"
     lodash "4.17.21"
@@ -1733,17 +1733,17 @@
     systemjs "0.20.19"
     tslib "2.4.0"
 
-"@grafana/schema@9.2.13":
-  version "9.2.13"
-  resolved "https://registry.yarnpkg.com/@grafana/schema/-/schema-9.2.13.tgz#737c97f33cc0f4ea5164812ead59b4d4a6f936ea"
-  integrity sha512-zyIiyVfJd9UqpP7gpGRXFqGzKlb8YFlo3SHeftODJog1OwhVoTTejimhSfYI8tWOHDIRy3SVmskDQG38ItQRYg==
+"@grafana/schema@9.2.18":
+  version "9.2.18"
+  resolved "https://registry.yarnpkg.com/@grafana/schema/-/schema-9.2.18.tgz#c9bce6690043aa23454b1543534d378f15dbb84a"
+  integrity sha512-dE416YydHgfJBXwv1tP96vbwFXmXzVtN8EECjhh0LhBehLFHb/BiZDxMpsplKT8hMwMjrgA4ZiX0fBu+0Lg38Q==
   dependencies:
     tslib "2.4.0"
 
-"@grafana/toolkit@9.2.13":
-  version "9.2.13"
-  resolved "https://registry.yarnpkg.com/@grafana/toolkit/-/toolkit-9.2.13.tgz#ecc08a194f15e5a0df9fe49f449893984ca0a15c"
-  integrity sha512-rq/MNFPbV2cQyqNQLKjEN9dVYnvPjy79weXM4sWQU9D377a0BXNzTbfcj5a5OG+NP5G6ddKyWGtJJoZ/WZxH3A==
+"@grafana/toolkit@9.2.18":
+  version "9.2.18"
+  resolved "https://registry.yarnpkg.com/@grafana/toolkit/-/toolkit-9.2.18.tgz#923b8f56f72e040af2d3e93b88a4935ad045ba0b"
+  integrity sha512-vS1z+/z9v8v4OiBl/f/PsDx/xVqMb8pg62s7d8mdHt4ZbFnxxCcDumQZu4ckwym8iaxEcPas4ua0wWhrIbyq6A==
   dependencies:
     "@babel/core" "7.18.9"
     "@babel/plugin-proposal-class-properties" "7.18.6"
@@ -1757,10 +1757,10 @@
     "@babel/preset-env" "7.18.9"
     "@babel/preset-react" "7.18.6"
     "@babel/preset-typescript" "7.18.6"
-    "@grafana/data" "9.2.13"
+    "@grafana/data" "9.2.18"
     "@grafana/eslint-config" "5.0.0"
     "@grafana/tsconfig" "^1.2.0-rc1"
-    "@grafana/ui" "9.2.13"
+    "@grafana/ui" "9.2.18"
     "@jest/core" "27.5.1"
     "@types/command-exists" "^1.2.0"
     "@types/eslint" "8.4.1"
@@ -1835,16 +1835,16 @@
   resolved "https://registry.yarnpkg.com/@grafana/tsconfig/-/tsconfig-1.2.0-rc1.tgz#10973c978ec95b0ea637511254b5f478bce04de7"
   integrity sha512-+SgQeBQ1pT6D/E3/dEdADqTrlgdIGuexUZ8EU+8KxQFKUeFeU7/3z/ayI2q/wpJ/Kr6WxBBNlrST6aOKia19Ag==
 
-"@grafana/ui@9.2.13":
-  version "9.2.13"
-  resolved "https://registry.yarnpkg.com/@grafana/ui/-/ui-9.2.13.tgz#44c6b125826cd586c362f532761acd3ffe6cefca"
-  integrity sha512-8m3MTqBzAuDRSp3E/UNZ5elvL4N49OVF4Do1otOdqLtkA4oQ8pICDQrDm2G7Ywnx27BG9fkAiYSSFa1IRRHcBw==
+"@grafana/ui@9.2.18":
+  version "9.2.18"
+  resolved "https://registry.yarnpkg.com/@grafana/ui/-/ui-9.2.18.tgz#e3c5d73684ead6b8d41d49f0a36bf20fb9867f54"
+  integrity sha512-zr/wySFHMv6T3MZzp8l4SRA+shmB98MrWgHTAF4zTXBYFkemk88DE/4KwTQRDBYCTWxdS100YTIdN90yZ0e/sg==
   dependencies:
     "@emotion/css" "11.9.0"
     "@emotion/react" "11.9.3"
-    "@grafana/data" "9.2.13"
-    "@grafana/e2e-selectors" "9.2.13"
-    "@grafana/schema" "9.2.13"
+    "@grafana/data" "9.2.18"
+    "@grafana/e2e-selectors" "9.2.18"
+    "@grafana/schema" "9.2.18"
     "@monaco-editor/react" "4.4.5"
     "@popperjs/core" "2.11.5"
     "@react-aria/button" "3.6.1"


### PR DESCRIPTION
Bump grafana version because of CVEs.

PMM-12114

Main PR: https://github.com/percona-platform/grafana/pull/668