### PR TITLE
PMM-12070 Table plugin - Mongo cluster summary

### DIFF
--- a/dashboards/MongoDB/MongoDB_Cluster_Summary.json
+++ b/dashboards/MongoDB/MongoDB_Cluster_Summary.json
@@ -285,47 +285,7 @@
       "type": "stat"
     },
     {
-      "activePatternIndex": 1,
-      "debug_mode": false,
-      "defaultPattern": {
-        "bgColors": "green|orange|red",
-        "bgColors_overrides": "0->green|2->red|1->yellow",
-        "clickable_cells_link": "",
-        "col_name": "Value",
-        "decimals": 2,
-        "defaultBGColor": "",
-        "defaultTextColor": "",
-        "delimiter": "|",
-        "displayTemplate": "_value_",
-        "enable_bgColor": false,
-        "enable_bgColor_overrides": false,
-        "enable_clickable_cells": false,
-        "enable_textColor": false,
-        "enable_textColor_overrides": false,
-        "enable_time_based_thresholds": false,
-        "enable_transform": false,
-        "enable_transform_overrides": false,
-        "filter": {
-          "value_above": "",
-          "value_below": ""
-        },
-        "format": "none",
-        "name": "Default Pattern",
-        "null_color": "darkred",
-        "null_textcolor": "black",
-        "null_value": "-",
-        "pattern": "*",
-        "row_col_wrapper": "_",
-        "row_name": "_series_",
-        "textColors": "red|orange|green",
-        "textColors_overrides": "0->red|2->green|1->yellow",
-        "thresholds": "70,90",
-        "time_based_thresholds": [],
-        "tooltipTemplate": "Series : _series_ <br/>Row Name : _row_name_ <br/>Col Name : _col_name_ <br/>Value : _value_",
-        "transform_values": "_value_|_value_|_value_",
-        "transform_values_overrides": "0->down|1->up",
-        "valueName": "current"
-      },
+      "collapsed": false,
       "default_title_for_rows": "DB Name",
       "description": "MongoDB stores documents in collections. Collections are analogous to tables in relational databases.",
       "gridPos": {
@@ -334,97 +294,124 @@
         "x": 8,
         "y": 1
       },
-      "hide_headers": false,
       "id": 1043,
-      "patterns": [
-        {
-          "bgColors": "blue|blue|blue",
-          "bgColors_overrides": "0->green|2->red|1->yellow",
-          "clickable_cells_link": "/graph/d/mongodb-replicaset-summary/mongodb-replset-summary?var-interval=$__auto_interval_interval&var-replset=_1_",
-          "col_name": "_1_",
-          "decimals": "0",
-          "defaultBGColor": "",
-          "defaultTextColor": "",
-          "delimiter": "|",
-          "displayTemplate": "_value_",
-          "enable_bgColor": true,
-          "enable_bgColor_overrides": false,
-          "enable_clickable_cells": true,
-          "enable_textColor": false,
-          "enable_textColor_overrides": false,
-          "enable_time_based_thresholds": false,
-          "enable_transform": false,
-          "enable_transform_overrides": false,
-          "filter": {
-            "value_above": "",
-            "value_below": ""
+      "pluginVersion": "9.2.20",
+      "title": "Amount of Collections in Shards",
+      "type": "table",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "left",
+            "displayMode": "auto",
+            "inspect": false,
+            "filterable": false
           },
-          "format": "none",
-          "name": "Collection",
-          "null_color": "blue",
-          "null_textcolor": "white",
-          "null_value": "0",
-          "pattern": ".*Collections",
-          "row_col_wrapper": "_",
-          "row_name": "_0_",
-          "textColors": "red|orange|green",
-          "textColors_overrides": "0->red|2->green|1->yellow",
-          "thresholds": "70,90",
-          "time_based_thresholds": [],
-          "tooltipTemplate": "-",
-          "transform_values": "_value_|_value_|_value_",
-          "transform_values_overrides": "0->down|1->up",
-          "valueName": "current"
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "color": "dark-blue",
+                  "index": 0
+                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 20
+              }
+            ]
+          },
+          "color": {
+            "fixedColor": "text",
+            "mode": "thresholds"
+          },
+          "noValue": "-"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^((?!(DB Name)).)*$"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background-solid"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "dark-blue"
+                }
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "",
+                    "url": "/graph/d/mongodb-replicaset-summary/mongodb-replset-summary?var-interval=$__auto_interval_interval&var-replset=${__field.name}"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "fields": ""
+        },
+        "frameIndex": 0,
+        "sortBy": [
+          {
+            "displayName": "DB Name\\Value",
+            "desc": false
+          }
+        ]
+      },
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "shard",
+            "rowField": "db",
+            "valueField": "Value"
+          }
         },
         {
-          "bgColors": "green|orange|red",
-          "bgColors_overrides": "0->green|2->red|1->yellow",
-          "clickable_cells_link": "",
-          "col_name": "_2_",
-          "decimals": 2,
-          "defaultBGColor": "",
-          "defaultTextColor": "",
-          "delimiter": "|",
-          "displayTemplate": "_value_",
-          "enable_bgColor": false,
-          "enable_bgColor_overrides": false,
-          "enable_clickable_cells": false,
-          "enable_textColor": false,
-          "enable_textColor_overrides": false,
-          "enable_time_based_thresholds": false,
-          "enable_transform": false,
-          "enable_transform_overrides": false,
-          "filter": {
-            "value_above": "",
-            "value_below": ""
-          },
-          "format": "none",
-          "name": "Size",
-          "null_color": "darkred",
-          "null_textcolor": "black",
-          "null_value": "No data",
-          "pattern": ".*Size",
-          "row_col_wrapper": "_",
-          "row_name": "_1_",
-          "textColors": "red|orange|green",
-          "textColors_overrides": "0->red|2->green|1->yellow",
-          "thresholds": "70,90",
-          "time_based_thresholds": [],
-          "tooltipTemplate": "Series : _series_ <br/>Row Name : _row_name_ <br/>Col Name : _col_name_ <br/>Value : _value_",
-          "transform_values": "_value_|_value_|_value_",
-          "transform_values_overrides": "0->down|1->up",
-          "valueName": "avg"
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "db\\shard": "DB Name",
+              "rs1": ""
+            }
+          }
         }
       ],
-      "row_col_wrapper": "_",
-      "sorting_props": {
-        "col_index": -1,
-        "direction": "desc"
-      },
       "targets": [
         {
           "expr": "max by (db,shard) (mongodb_mongos_db_collections_total{cluster=\"$cluster\",db!~\"admin|config\"})",
-          "format": "time_series",
+          "editorMode": "code",
+          "range": false,
+          "exemplar": false,
+          "format": "table",
           "hide": false,
           "instant": true,
           "interval": "$interval",
@@ -433,58 +420,23 @@
         },
         {
           "expr": "mongodb_mongos_db_data_size_bytes{cluster=\"$cluster\",db!~\"admin|config\"}",
+          "editorMode": "code",
+          "range": false,
+          "exemplar": false,
+          "format": "table",
           "hide": true,
           "instant": true,
-          "interval": "$intgerval",
-          "legendFormat": "{{db}} | {{shard}} | Size",
+          "interval": "$interval",
+          "legendFormat": "{{db}} | {{shard}} | Collections",
           "refId": "B"
         }
       ],
-      "title": "Amount of Collections in Shards",
-      "type": "yesoreyeram-boomtable-panel"
+      "sorting_props": {
+        "col_index": -1,
+        "direction": "desc"
+      }
     },
     {
-      "activePatternIndex": 0,
-      "debug_mode": false,
-      "defaultPattern": {
-        "bgColors": "green|orange|red",
-        "bgColors_overrides": "0->green|2->red|1->yellow",
-        "clickable_cells_link": "",
-        "col_name": "Value",
-        "decimals": 2,
-        "defaultBGColor": "",
-        "defaultTextColor": "",
-        "delimiter": "|",
-        "displayTemplate": "_value_",
-        "enable_bgColor": false,
-        "enable_bgColor_overrides": false,
-        "enable_clickable_cells": false,
-        "enable_textColor": false,
-        "enable_textColor_overrides": false,
-        "enable_time_based_thresholds": false,
-        "enable_transform": false,
-        "enable_transform_overrides": false,
-        "filter": {
-          "value_above": "",
-          "value_below": ""
-        },
-        "format": "none",
-        "name": "Default Pattern",
-        "null_color": "darkred",
-        "null_textcolor": "black",
-        "null_value": "No data",
-        "pattern": "*",
-        "row_col_wrapper": "_",
-        "row_name": "_series_",
-        "textColors": "red|orange|green",
-        "textColors_overrides": "0->red|2->green|1->yellow",
-        "thresholds": "70,90",
-        "time_based_thresholds": [],
-        "tooltipTemplate": "Series : _series_ <br/>Row Name : _row_name_ <br/>Col Name : _col_name_ <br/>Value : _value_",
-        "transform_values": "_value_|_value_|_value_",
-        "transform_values_overrides": "0->down|1->up",
-        "valueName": "current"
-      },
       "default_title_for_rows": "DB Name",
       "description": "MongoDB stores documents in collections. Collections are analogous to tables in relational databases.",
       "gridPos": {
@@ -495,56 +447,125 @@
       },
       "hide_headers": false,
       "id": 1030,
-      "patterns": [
-        {
-          "bgColors": "blue|blue|blue",
-          "bgColors_overrides": "0->green|2->red|1->yellow",
-          "clickable_cells_link": "/graph/d/mongodb-replicaset-summary/mongodb-replset-summary?var-interval=$__auto_interval_interval&var-replset=_1_",
-          "col_name": "_1_",
-          "decimals": "0",
-          "defaultBGColor": "",
-          "defaultTextColor": "",
-          "delimiter": "|",
-          "displayTemplate": "_value_",
-          "enable_bgColor": true,
-          "enable_bgColor_overrides": false,
-          "enable_clickable_cells": true,
-          "enable_textColor": false,
-          "enable_textColor_overrides": false,
-          "enable_time_based_thresholds": false,
-          "enable_transform": false,
-          "enable_transform_overrides": false,
-          "filter": {
-            "value_above": "",
-            "value_below": ""
+      "pluginVersion": "9.2.20",
+      "title": "Size of Collections in Shards",
+      "type": "table",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "left",
+            "displayMode": "auto",
+            "inspect": false,
+            "filterable": false
           },
-          "format": "bytes",
-          "name": "Size",
-          "null_color": "blue",
-          "null_textcolor": "white",
-          "null_value": "0",
-          "pattern": ".*Collections",
-          "row_col_wrapper": "_",
-          "row_name": "_0_",
-          "textColors": "red|orange|green",
-          "textColors_overrides": "0->red|2->green|1->yellow",
-          "thresholds": "70,90",
-          "time_based_thresholds": [],
-          "tooltipTemplate": "-",
-          "transform_values": "_value_|_value_|_value_",
-          "transform_values_overrides": "0->down|1->up",
-          "valueName": "current"
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "color": "dark-blue",
+                  "index": 0,
+                  "text": "0"
+                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 20
+              }
+            ]
+          },
+          "color": {
+            "fixedColor": "text",
+            "mode": "thresholds"
+          },
+          "noValue": "-",
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^((?!(DB Name)).)*$"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background-solid"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "dark-blue"
+                }
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "",
+                    "url": "/graph/d/mongodb-replicaset-summary/mongodb-replset-summary?var-interval=$__auto_interval_interval&var-replset=${__field.name}"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "fields": ""
+        },
+        "frameIndex": 0,
+        "sortBy": [
+          {
+            "displayName": "DB Name\\Value",
+            "desc": false
+          }
+        ]
+      },
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "shard",
+            "rowField": "db",
+            "valueField": "Value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "db\\shard": "DB Name",
+              "rs1": ""
+            }
+          }
         }
       ],
-      "row_col_wrapper": "_",
-      "sorting_props": {
-        "col_index": -1,
-        "direction": "desc"
-      },
       "targets": [
         {
           "expr": "max by (db,shard) (mongodb_mongos_db_data_size_bytes{cluster=\"$cluster\",db!~\"admin|config\"})",
-          "format": "time_series",
+          "editorMode": "code",
+          "range": false,
+          "exemplar": false,
+          "format": "table",
           "hide": false,
           "instant": true,
           "interval": "$interval",
@@ -552,9 +573,10 @@
           "refId": "A"
         }
       ],
-      "text_alignment_header": "center",
-      "title": "Size of Collections in Shards",
-      "type": "yesoreyeram-boomtable-panel"
+      "sorting_props": {
+        "col_index": -1,
+        "direction": "desc"
+      }
     },
     {
       "description": "A shard contains a subset of sharded data for a sharded cluster. Together, the cluster’s shards hold the entire data set for the cluster.",
@@ -1478,47 +1500,6 @@
       "writeMetricNames": false
     },
     {
-      "activePatternIndex": 0,
-      "debug_mode": false,
-      "defaultPattern": {
-        "bgColors": "green|orange|red",
-        "bgColors_overrides": "0->green|2->red|1->yellow",
-        "clickable_cells_link": "",
-        "col_name": "Value",
-        "decimals": 2,
-        "defaultBGColor": "",
-        "defaultTextColor": "",
-        "delimiter": "|",
-        "displayTemplate": "_value_",
-        "enable_bgColor": false,
-        "enable_bgColor_overrides": false,
-        "enable_clickable_cells": false,
-        "enable_textColor": false,
-        "enable_textColor_overrides": false,
-        "enable_time_based_thresholds": false,
-        "enable_transform": false,
-        "enable_transform_overrides": false,
-        "filter": {
-          "value_above": "",
-          "value_below": ""
-        },
-        "format": "none",
-        "name": "Default Pattern",
-        "null_color": "darkred",
-        "null_textcolor": "black",
-        "null_value": "No data",
-        "pattern": "*",
-        "row_col_wrapper": "_",
-        "row_name": "_series_",
-        "textColors": "red|orange|green",
-        "textColors_overrides": "0->red|2->green|1->yellow",
-        "thresholds": "70,90",
-        "time_based_thresholds": [],
-        "tooltipTemplate": "Series : _series_ <br/>Row Name : _row_name_ <br/>Col Name : _col_name_ <br/>Value : _value_",
-        "transform_values": "_value_|_value_|_value_",
-        "transform_values_overrides": "0->down|1->up",
-        "valueName": "current"
-      },
       "default_title_for_rows": "Shard Name",
       "description": "A chunk consists of a subset of sharded data.",
       "gridPos": {
@@ -1529,67 +1510,102 @@
       },
       "hide_headers": false,
       "id": 1200,
-      "patterns": [
-        {
-          "bgColors": "blue|blue|blue",
-          "bgColors_overrides": "0->green|2->red|1->yellow",
-          "clickable_cells_link": "/graph/d/mongodb-replicaset-summary/mongodb-replset-summary?var-interval=$__auto_interval_interval&var-replset=_0_",
-          "col_name": "_1_",
-          "decimals": "0",
-          "defaultBGColor": "",
-          "defaultTextColor": "",
-          "delimiter": "|",
-          "displayTemplate": "_value_",
-          "enable_bgColor": true,
-          "enable_bgColor_overrides": false,
-          "enable_clickable_cells": true,
-          "enable_textColor": false,
-          "enable_textColor_overrides": false,
-          "enable_time_based_thresholds": false,
-          "enable_transform": false,
-          "enable_transform_overrides": false,
-          "filter": {
-            "value_above": "",
-            "value_below": ""
+      "pluginVersion": "9.2.20",
+      "title": "Amount of Chunks in Shards",
+      "type": "table",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "left",
+            "displayMode": "auto",
+            "inspect": false,
+            "filterable": false
           },
-          "format": "none",
-          "name": "Collection",
-          "null_color": "darkred",
-          "null_textcolor": "black",
-          "null_value": "No data",
-          "pattern": ".*Chunks",
-          "row_col_wrapper": "_",
-          "row_name": "_0_",
-          "textColors": "red|orange|green",
-          "textColors_overrides": "0->red|2->green|1->yellow",
-          "thresholds": "70,90",
-          "time_based_thresholds": [],
-          "tooltipTemplate": "-",
-          "transform_values": "_value_|_value_|_value_",
-          "transform_values_overrides": "0->down|1->up",
-          "valueName": "current"
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 20
+              }
+            ]
+          },
+          "color": {
+            "fixedColor": "text",
+            "mode": "thresholds"
+          },
+          "noValue": "-"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Chunks"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background-solid"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "dark-blue"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "fields": ""
+        }
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "shard": "Shard Name",
+              "Value": "Chunks"
+            }
+          }
         }
       ],
-      "row_col_wrapper": "_",
-      "sorting_props": {
-        "col_index": -1,
-        "direction": "desc"
-      },
       "targets": [
         {
-          "exemplar": true,
           "expr": "avg by (shard) (mongodb_mongos_sharding_shard_chunks_total{cluster=\"$cluster\",db!~\"admin|config\"})",
-          "format": "time_series",
+          "editorMode": "code",
+          "range": false,
+          "exemplar": false,
+          "format": "table",
           "hide": false,
           "instant": true,
           "interval": "$interval",
-          "legendFormat": "{{shard}} | Chunks",
+          "legendFormat": "{{db}} | {{shard}} | Collections",
           "refId": "A"
         }
       ],
-      "text_alignment_header": "center",
-      "title": "Amount of Chunks in Shards",
-      "type": "yesoreyeram-boomtable-panel"
+      "sorting_props": {
+        "col_index": -1,
+        "direction": "desc"
+      }
     },
     {
       "aliasColors": {},
@@ -1887,47 +1903,6 @@
       "type": "row"
     },
     {
-      "activePatternIndex": 0,
-      "debug_mode": false,
-      "defaultPattern": {
-        "bgColors": "green|orange|red",
-        "bgColors_overrides": "0->green|2->red|1->yellow",
-        "clickable_cells_link": "",
-        "col_name": "Value",
-        "decimals": 2,
-        "defaultBGColor": "",
-        "defaultTextColor": "",
-        "delimiter": "|",
-        "displayTemplate": "_value_",
-        "enable_bgColor": false,
-        "enable_bgColor_overrides": false,
-        "enable_clickable_cells": false,
-        "enable_textColor": false,
-        "enable_textColor_overrides": false,
-        "enable_time_based_thresholds": false,
-        "enable_transform": false,
-        "enable_transform_overrides": false,
-        "filter": {
-          "value_above": "",
-          "value_below": ""
-        },
-        "format": "none",
-        "name": "Default Pattern",
-        "null_color": "darkred",
-        "null_textcolor": "black",
-        "null_value": "No data",
-        "pattern": "*",
-        "row_col_wrapper": "_",
-        "row_name": "_series_",
-        "textColors": "red|orange|green",
-        "textColors_overrides": "0->red|2->green|1->yellow",
-        "thresholds": "70,90",
-        "time_based_thresholds": [],
-        "tooltipTemplate": "Series : _series_ <br/>Row Name : _row_name_ <br/>Col Name : _col_name_ <br/>Value : _value_",
-        "transform_values": "_value_|_value_|_value_",
-        "transform_values_overrides": "0->down|1->up",
-        "valueName": "current"
-      },
       "default_title_for_rows": "DB Name",
       "description": "Indexes are special data structures that store a small portion of the collection’s data set in an easy to traverse form. ",
       "gridPos": {
@@ -1938,96 +1913,124 @@
       },
       "hide_headers": false,
       "id": 1040,
-      "patterns": [
-        {
-          "bgColors": "blue|blue|blue",
-          "bgColors_overrides": "0->green|2->red|1->yellow",
-          "clickable_cells_link": "/graph/d/mongodb-replicaset-summary/mongodb-replset-summary?var-interval=$__auto_interval_interval&var-replset=_1_",
-          "col_name": "_1_",
-          "decimals": "0",
-          "defaultBGColor": "",
-          "defaultTextColor": "",
-          "delimiter": "|",
-          "displayTemplate": "_value_",
-          "enable_bgColor": true,
-          "enable_bgColor_overrides": false,
-          "enable_clickable_cells": true,
-          "enable_textColor": false,
-          "enable_textColor_overrides": false,
-          "enable_time_based_thresholds": false,
-          "enable_transform": false,
-          "enable_transform_overrides": false,
-          "filter": {
-            "value_above": "",
-            "value_below": ""
+      "pluginVersion": "9.2.20",
+      "title": "Amount of Indexes in Shards",
+      "type": "table",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "left",
+            "displayMode": "auto",
+            "inspect": false,
+            "filterable": false
           },
-          "format": "none",
-          "name": "Collection",
-          "null_color": "darkred",
-          "null_textcolor": "black",
-          "null_value": "No data",
-          "pattern": ".*Collections",
-          "row_col_wrapper": "_",
-          "row_name": "_0_",
-          "textColors": "red|orange|green",
-          "textColors_overrides": "0->red|2->green|1->yellow",
-          "thresholds": "70,90",
-          "time_based_thresholds": [],
-          "tooltipTemplate": "-",
-          "transform_values": "_value_|_value_|_value_",
-          "transform_values_overrides": "0->down|1->up",
-          "valueName": "current"
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "dark-red",
+                  "index": 0,
+                  "text": "No data"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 20
+              }
+            ]
+          },
+          "color": {
+            "fixedColor": "text",
+            "mode": "thresholds"
+          },
+          "noValue": "-"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^((?!(DB Name)).)*$"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background-solid"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "dark-blue"
+                }
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "",
+                    "url": "/graph/d/mongodb-replicaset-summary/mongodb-replset-summary?var-interval=$__auto_interval_interval&var-replset=${__field.name}"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "fields": ""
+        },
+        "frameIndex": 0,
+        "sortBy": [
+          {
+            "displayName": "DB Name\\Value",
+            "desc": false
+          }
+        ]
+      },
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "shard",
+            "rowField": "db",
+            "valueField": "Value"
+          }
         },
         {
-          "bgColors": "green|orange|red",
-          "bgColors_overrides": "0->green|2->red|1->yellow",
-          "clickable_cells_link": "",
-          "col_name": "_2_",
-          "decimals": 2,
-          "defaultBGColor": "",
-          "defaultTextColor": "",
-          "delimiter": "|",
-          "displayTemplate": "_value_",
-          "enable_bgColor": false,
-          "enable_bgColor_overrides": false,
-          "enable_clickable_cells": false,
-          "enable_textColor": false,
-          "enable_textColor_overrides": false,
-          "enable_time_based_thresholds": false,
-          "enable_transform": false,
-          "enable_transform_overrides": false,
-          "filter": {
-            "value_above": "",
-            "value_below": ""
-          },
-          "format": "none",
-          "name": "Size",
-          "null_color": "darkred",
-          "null_textcolor": "black",
-          "null_value": "No data",
-          "pattern": ".*Size",
-          "row_col_wrapper": "_",
-          "row_name": "_1_",
-          "textColors": "red|orange|green",
-          "textColors_overrides": "0->red|2->green|1->yellow",
-          "thresholds": "70,90",
-          "time_based_thresholds": [],
-          "tooltipTemplate": "Series : _series_ <br/>Row Name : _row_name_ <br/>Col Name : _col_name_ <br/>Value : _value_",
-          "transform_values": "_value_|_value_|_value_",
-          "transform_values_overrides": "0->down|1->up",
-          "valueName": "avg"
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "db\\shard": "DB Name",
+              "rs1": ""
+            }
+          }
         }
       ],
-      "row_col_wrapper": "_",
-      "sorting_props": {
-        "col_index": -1,
-        "direction": "desc"
-      },
       "targets": [
         {
-          "exemplar": true,
           "expr": "avg by (db,shard) (mongodb_mongos_db_indexes_total{cluster=\"$cluster\",db!~\"admin|config\"})",
-          "format": "time_series",
+          "editorMode": "code",
+          "range": false,
+          "exemplar": false,
+          "format": "table",
           "hide": false,
           "instant": true,
           "interval": "$interval",
@@ -2036,16 +2039,21 @@
         },
         {
           "expr": "mongodb_mongos_db_data_size_bytes{cluster=\"$cluster\",db!~\"admin|config\"}",
+          "editorMode": "code",
+          "range": false,
+          "exemplar": false,
+          "format": "table",
           "hide": true,
           "instant": true,
-          "interval": "$intgerval",
-          "legendFormat": "{{db}} | {{shard}} | Size",
+          "interval": "$interval",
+          "legendFormat": "{{db}} | {{shard}} | Collections",
           "refId": "B"
         }
       ],
-      "text_alignment_header": "center",
-      "title": "Amount of Indexes in Shards",
-      "type": "yesoreyeram-boomtable-panel"
+      "sorting_props": {
+        "col_index": -1,
+        "direction": "desc"
+      }
     },
     {
       "aliasColors": {},
@@ -2140,47 +2148,6 @@
       }
     },
     {
-      "activePatternIndex": 0,
-      "debug_mode": false,
-      "defaultPattern": {
-        "bgColors": "green|orange|red",
-        "bgColors_overrides": "0->green|2->red|1->yellow",
-        "clickable_cells_link": "",
-        "col_name": "Value",
-        "decimals": 2,
-        "defaultBGColor": "",
-        "defaultTextColor": "",
-        "delimiter": "|",
-        "displayTemplate": "_value_",
-        "enable_bgColor": false,
-        "enable_bgColor_overrides": false,
-        "enable_clickable_cells": false,
-        "enable_textColor": false,
-        "enable_textColor_overrides": false,
-        "enable_time_based_thresholds": false,
-        "enable_transform": false,
-        "enable_transform_overrides": false,
-        "filter": {
-          "value_above": "",
-          "value_below": ""
-        },
-        "format": "none",
-        "name": "Default Pattern",
-        "null_color": "darkred",
-        "null_textcolor": "black",
-        "null_value": "No data",
-        "pattern": "*",
-        "row_col_wrapper": "_",
-        "row_name": "_series_",
-        "textColors": "red|orange|green",
-        "textColors_overrides": "0->red|2->green|1->yellow",
-        "thresholds": "70,90",
-        "time_based_thresholds": [],
-        "tooltipTemplate": "Series : _series_ <br/>Row Name : _row_name_ <br/>Col Name : _col_name_ <br/>Value : _value_",
-        "transform_values": "_value_|_value_|_value_",
-        "transform_values_overrides": "0->down|1->up",
-        "valueName": "current"
-      },
       "default_title_for_rows": "DB Name",
       "description": "The index stores the value of a specific field or set of fields, ordered by the value of the field. ",
       "gridPos": {
@@ -2191,58 +2158,124 @@
       },
       "hide_headers": false,
       "id": 1072,
-      "patterns": [
-        {
-          "bgColors": "blue|blue|blue",
-          "bgColors_overrides": "0->green|2->red|1->yellow",
-          "clickable_cells_link": "/graph/d/mongodb-replicaset-summary/mongodb-replset-summary?var-interval=$__auto_interval_interval&var-replset=_1_",
-          "col_name": "_1_",
-          "decimals": "0",
-          "defaultBGColor": "",
-          "defaultTextColor": "",
-          "delimiter": "|",
-          "displayTemplate": "_value_",
-          "enable_bgColor": true,
-          "enable_bgColor_overrides": false,
-          "enable_clickable_cells": true,
-          "enable_textColor": false,
-          "enable_textColor_overrides": false,
-          "enable_time_based_thresholds": false,
-          "enable_transform": false,
-          "enable_transform_overrides": false,
-          "filter": {
-            "value_above": "",
-            "value_below": ""
+      "pluginVersion": "9.2.20",
+      "title": "Size of Indexes in Shards",
+      "type": "table",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "left",
+            "displayMode": "auto",
+            "inspect": false,
+            "filterable": false
           },
-          "format": "bytes",
-          "name": "Size",
-          "null_color": "darkred",
-          "null_textcolor": "black",
-          "null_value": "No data",
-          "pattern": ".*Collections",
-          "row_col_wrapper": "_",
-          "row_name": "_0_",
-          "textColors": "red|orange|green",
-          "textColors_overrides": "0->red|2->green|1->yellow",
-          "thresholds": "70,90",
-          "time_based_thresholds": [],
-          "tooltipTemplate": "-",
-          "transform_values": "_value_|_value_|_value_",
-          "transform_values_overrides": "0->down|1->up",
-          "valueName": "current"
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "dark-red",
+                  "index": 0,
+                  "text": "No data"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 20
+              }
+            ]
+          },
+          "color": {
+            "fixedColor": "text",
+            "mode": "thresholds"
+          },
+          "noValue": "-",
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "^((?!(DB Name)).)*$"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background-solid"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "dark-blue"
+                }
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "",
+                    "url": "/graph/d/mongodb-replicaset-summary/mongodb-replset-summary?var-interval=$__auto_interval_interval&var-replset=${__field.name}"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "fields": ""
+        },
+        "frameIndex": 0,
+        "sortBy": [
+          {
+            "displayName": "DB Name\\Value",
+            "desc": false
+          }
+        ]
+      },
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "shard",
+            "rowField": "db",
+            "valueField": "Value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "db\\shard": "DB Name",
+              "rs1": ""
+            }
+          }
         }
       ],
-      "row_col_wrapper": "_",
-      "sorting_props": {
-        "col_index": -1,
-        "direction": "desc"
-      },
       "targets": [
-        {
-          "datasource": "Metrics",
+        {          
+          "editorMode": "code",
           "exemplar": false,
           "expr": "avg by (db,shard) (mongodb_mongos_db_index_size_bytes{cluster=\"$cluster\",db!~\"admin|config\"})",
-          "format": "time_series",
+          "format": "table",
           "hide": false,
           "instant": true,
           "interval": "$interval",
@@ -2250,9 +2283,10 @@
           "refId": "A"
         }
       ],
-      "text_alignment_header": "center",
-      "title": "Size of Indexes in Shards",
-      "type": "yesoreyeram-boomtable-panel"
+      "sorting_props": {
+        "col_index": -1,
+        "direction": "desc"
+      }
     },
     {
       "aliasColors": {},
@@ -2357,53 +2391,8 @@
       "id": 1071,
       "panels": [
         {
-          "activePatternIndex": 0,
-          "debug_mode": false,
-          "defaultPattern": {
-            "bgColors": "green|orange|red",
-            "bgColors_overrides": "0->green|2->red|1->yellow",
-            "clickable_cells_link": "",
-            "col_name": "Value",
-            "decimals": 2,
-            "defaultBGColor": "",
-            "defaultTextColor": "",
-            "delimiter": "|",
-            "displayTemplate": "_value_",
-            "enable_bgColor": false,
-            "enable_bgColor_overrides": false,
-            "enable_clickable_cells": false,
-            "enable_textColor": false,
-            "enable_textColor_overrides": false,
-            "enable_time_based_thresholds": false,
-            "enable_transform": false,
-            "enable_transform_overrides": false,
-            "filter": {
-              "value_above": "",
-              "value_below": ""
-            },
-            "format": "none",
-            "name": "Default Pattern",
-            "null_color": "darkred",
-            "null_textcolor": "black",
-            "null_value": "No data",
-            "pattern": "*",
-            "row_col_wrapper": "_",
-            "row_name": "_series_",
-            "textColors": "red|orange|green",
-            "textColors_overrides": "0->red|2->green|1->yellow",
-            "thresholds": "70,90",
-            "time_based_thresholds": [],
-            "tooltipTemplate": "Series : _series_ <br/>Row Name : _row_name_ <br/>Col Name : _col_name_ <br/>Value : _value_",
-            "transform_values": "_value_|_value_|_value_",
-            "transform_values_overrides": "0->down|1->up",
-            "valueName": "current"
-          },
           "default_title_for_rows": "DB Name",
           "description": "Documents in MongoDB are objects stored in a format called BSON, a binary-encoded superset of JSON that supports additional data types.",
-          "fieldConfig": {
-            "defaults": {},
-            "overrides": []
-          },
           "gridPos": {
             "h": 8,
             "w": 8,
@@ -2412,57 +2401,123 @@
           },
           "hide_headers": false,
           "id": 1066,
-          "patterns": [
-            {
-              "bgColors": "blue|blue|blue",
-              "bgColors_overrides": "0->green|2->red|1->yellow",
-              "clickable_cells_link": "/graph/d/mongodb-replicaset-summary/mongodb-replset-summary?var-interval=$__auto_interval_interval&var-replset=_1_",
-              "col_name": "_1_",
-              "decimals": "0",
-              "defaultBGColor": "",
-              "defaultTextColor": "",
-              "delimiter": "|",
-              "displayTemplate": "_value_",
-              "enable_bgColor": true,
-              "enable_bgColor_overrides": false,
-              "enable_clickable_cells": true,
-              "enable_textColor": false,
-              "enable_textColor_overrides": false,
-              "enable_time_based_thresholds": false,
-              "enable_transform": false,
-              "enable_transform_overrides": false,
-              "filter": {
-                "value_above": "",
-                "value_below": ""
+          "pluginVersion": "9.2.20",
+          "title": "Amount of Objects in Shards",
+          "type": "table",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "left",
+                "displayMode": "auto",
+                "inspect": false,
+                "filterable": false
               },
-              "format": "none",
-              "name": "Collection",
-              "null_color": "darkred",
-              "null_textcolor": "black",
-              "null_value": "No data",
-              "pattern": ".*Collections",
-              "row_col_wrapper": "_",
-              "row_name": "_0_",
-              "textColors": "red|orange|green",
-              "textColors_overrides": "0->red|2->green|1->yellow",
-              "thresholds": "70,90",
-              "time_based_thresholds": [],
-              "tooltipTemplate": "-",
-              "transform_values": "_value_|_value_|_value_",
-              "transform_values_overrides": "0->down|1->up",
-              "valueName": "current"
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "dark-red",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 20
+                  }
+                ]
+              },
+              "color": {
+                "fixedColor": "text",
+                "mode": "thresholds"
+              },
+              "noValue": "-"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "^((?!(DB Name)).)*$"
+                },
+                "properties": [
+                  {
+                    "id": "custom.displayMode",
+                    "value": "color-background-solid"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "fixed",
+                      "fixedColor": "dark-blue"
+                    }
+                  },
+                  {
+                    "id": "links",
+                    "value": [
+                      {
+                        "title": "",
+                        "url": "/graph/d/mongodb-replicaset-summary/mongodb-replset-summary?var-interval=$__auto_interval_interval&var-replset=${__field.name}"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "options": {
+            "showHeader": true,
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "fields": ""
+            },
+            "frameIndex": 0,
+            "sortBy": [
+              {
+                "displayName": "DB Name\\Value",
+                "desc": false
+              }
+            ]
+          },
+          "transformations": [
+            {
+              "id": "groupingToMatrix",
+              "options": {
+                "columnField": "shard",
+                "rowField": "db",
+                "valueField": "Value"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {},
+                "indexByName": {},
+                "renameByName": {
+                  "db\\shard": "DB Name",
+                  "rs1": ""
+                }
+              }
             }
           ],
-          "row_col_wrapper": "_",
-          "sorting_props": {
-            "col_index": -1,
-            "direction": "desc"
-          },
           "targets": [
             {
-              "exemplar": true,
+              "datasource": "Metrics",
+              "exemplar": false,
               "expr": "avg by (db,shard) (mongodb_mongos_db_objects_total{cluster=\"$cluster\",db!~\"admin|config\"})",
-              "format": "time_series",
+              "format": "table",
               "hide": false,
               "instant": true,
               "interval": "$interval",
@@ -2470,9 +2525,10 @@
               "refId": "A"
             }
           ],
-          "text_alignment_header": "center",
-          "title": "Amount of Objects in Shards",
-          "type": "yesoreyeram-boomtable-panel"
+          "sorting_props": {
+            "col_index": -1,
+            "direction": "desc"
+          }
         },
         {
           "aliasColors": {},

--- a/dashboards/MongoDB/MongoDB_Cluster_Summary.json
+++ b/dashboards/MongoDB/MongoDB_Cluster_Summary.json
@@ -427,7 +427,7 @@
           "hide": true,
           "instant": true,
           "interval": "$interval",
-          "legendFormat": "{{db}} | {{shard}} | Collections",
+          "legendFormat": "{{db}} | {{shard}} | Size",
           "refId": "B"
         }
       ],
@@ -1598,7 +1598,7 @@
           "hide": false,
           "instant": true,
           "interval": "$interval",
-          "legendFormat": "{{db}} | {{shard}} | Collections",
+          "legendFormat": "{{shard}} | Chunks",
           "refId": "A"
         }
       ],
@@ -2046,7 +2046,7 @@
           "hide": true,
           "instant": true,
           "interval": "$interval",
-          "legendFormat": "{{db}} | {{shard}} | Collections",
+          "legendFormat": "{{db}} | {{shard}} | Size",
           "refId": "B"
         }
       ],


### PR DESCRIPTION
[PMM-12070](https://jira.percona.com/browse/PMM-12070) Change boomtable plugin to grafana table plugin for MongoDB cluster summary dashboard

FB - https://github.com/Percona-Lab/pmm-submodules/pull/3343#issuecomment-1639603106

Before - 
![mcs1](https://github.com/percona/grafana-dashboards/assets/119680679/2b740dd3-5da3-4f7c-88b3-3a30e861a136)
![mcs2](https://github.com/percona/grafana-dashboards/assets/119680679/108808c4-ebb2-4d86-b83c-c369eed08878)
![mcs3](https://github.com/percona/grafana-dashboards/assets/119680679/971f54b8-c9d9-4949-b1fc-1cf8fc7c2e2f)


After - 
![mcs4](https://github.com/percona/grafana-dashboards/assets/119680679/b1199378-a79f-4356-b2bb-647c5cc5bc5e)
![mcs5](https://github.com/percona/grafana-dashboards/assets/119680679/16929e3b-3060-46a4-9b6a-5db04b67affa)
![mcs6](https://github.com/percona/grafana-dashboards/assets/119680679/c9c2c8c6-e5cb-4f4c-9297-eb681ce87005)


