### PR TITLE
PMM-12425 fix infinite loop for setting timerange

### DIFF
--- a/pmm-app/src/pmm-qan/panel/provider/provider.tsx
+++ b/pmm-app/src/pmm-qan/panel/provider/provider.tsx
@@ -210,17 +210,8 @@ export const UrlParametersProvider = (props) => {
   const [previousState, setPreviousState] = useState(panelState);
 
   useEffect(() => {
-    const newTo = getAbsoluteTime(timeRange.raw.to);
-
-    if (newTo === 'now') {
-      setToTimeMomentValue(timeRange.to.subtract(1, 'minute')
-        .format('YYYY-MM-DDTHH:mm:ssZ'));
-      setFromTimeMomentValue(timeRange.from.subtract(1, 'minute')
-        .format('YYYY-MM-DDTHH:mm:ssZ'));
-    } else {
-      setToTimeMomentValue(timeRange.to.format('YYYY-MM-DDTHH:mm:ssZ'));
-      setFromTimeMomentValue(timeRange.from.format('YYYY-MM-DDTHH:mm:ssZ'));
-    }
+    setToTimeMomentValue(timeRange.to.format('YYYY-MM-DDTHH:mm:ssZ'));
+    setFromTimeMomentValue(timeRange.from.format('YYYY-MM-DDTHH:mm:ssZ'));
   }, [timeRange, from, to]);
 
   useEffect(() => {

--- a/pmm-app/src/pmm-qan/panel/provider/provider.tsx
+++ b/pmm-app/src/pmm-qan/panel/provider/provider.tsx
@@ -3,6 +3,7 @@ import { isEqual, omit } from 'lodash';
 import { parseURL, refreshGrafanaVariables, setLabels } from './provider.tools';
 import { QueryAnalyticsContext } from './provider.types';
 import { ParseQueryParamDate } from '../../../shared/components/helpers/time-parameters-parser';
+import moment from 'moment';
 
 const initialState = {} as QueryAnalyticsContext;
 
@@ -210,8 +211,23 @@ export const UrlParametersProvider = (props) => {
   const [previousState, setPreviousState] = useState(panelState);
 
   useEffect(() => {
-    setToTimeMomentValue(timeRange.to.format('YYYY-MM-DDTHH:mm:ssZ'));
-    setFromTimeMomentValue(timeRange.from.format('YYYY-MM-DDTHH:mm:ssZ'));
+    const newTo = getAbsoluteTime(timeRange.raw.to);
+    if (newTo === 'now') {
+      setToTimeMomentValue(timeRange.to.subtract(1, 'minute')
+        .format('YYYY-MM-DDTHH:mm:ssZ'));
+
+      if (moment.isMoment(timeRange.raw.from)) {
+        setFromTimeMomentValue(timeRange.from.format('YYYY-MM-DDTHH:mm:ssZ'));
+      } else {
+        setFromTimeMomentValue(timeRange.from.subtract(1, 'minute')
+          .format('YYYY-MM-DDTHH:mm:ssZ'));
+      }
+    }
+    else {
+      setToTimeMomentValue(timeRange.to.format('YYYY-MM-DDTHH:mm:ssZ'));
+      setFromTimeMomentValue(timeRange.from.format('YYYY-MM-DDTHH:mm:ssZ'));
+    }
+
   }, [timeRange, from, to]);
 
   useEffect(() => {

--- a/pmm-app/src/pmm-qan/panel/provider/provider.tsx
+++ b/pmm-app/src/pmm-qan/panel/provider/provider.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { isEqual, omit } from 'lodash';
+import moment from 'moment';
 import { parseURL, refreshGrafanaVariables, setLabels } from './provider.tools';
 import { QueryAnalyticsContext } from './provider.types';
 import { ParseQueryParamDate } from '../../../shared/components/helpers/time-parameters-parser';
-import moment from 'moment';
 
 const initialState = {} as QueryAnalyticsContext;
 
@@ -212,6 +212,7 @@ export const UrlParametersProvider = (props) => {
 
   useEffect(() => {
     const newTo = getAbsoluteTime(timeRange.raw.to);
+
     if (newTo === 'now') {
       setToTimeMomentValue(timeRange.to.subtract(1, 'minute')
         .format('YYYY-MM-DDTHH:mm:ssZ'));
@@ -222,12 +223,10 @@ export const UrlParametersProvider = (props) => {
         setFromTimeMomentValue(timeRange.from.subtract(1, 'minute')
           .format('YYYY-MM-DDTHH:mm:ssZ'));
       }
-    }
-    else {
+    } else {
       setToTimeMomentValue(timeRange.to.format('YYYY-MM-DDTHH:mm:ssZ'));
       setFromTimeMomentValue(timeRange.from.format('YYYY-MM-DDTHH:mm:ssZ'));
     }
-
   }, [timeRange, from, to]);
 
   useEffect(() => {


### PR DESCRIPTION
[PMM-12425 ](https://jira.percona.com/browse/PMM-12425) - QAN picking different date range will cause an error

![qan2](https://github.com/percona/grafana-dashboards/assets/119680679/5ca45a1a-8137-42b4-90d7-c3fc5ee4f96d)

![Screenshot 2023-11-22 123534](https://github.com/percona/grafana-dashboards/assets/119680679/9ede30a7-236a-424d-a698-9cbf8e49386a)

Previous fixes should be tested after this fix -
[PMM-9987](https://jira.percona.com/browse/PMM-9987)
[PMM-10483](https://jira.percona.com/browse/PMM-10483) 