### PR TITLE
OS/Network_Details: Fix outgoing resets/segments not shown

### DIFF
--- a/dashboards/OS/Network_Details.json
+++ b/dashboards/OS/Network_Details.json
@@ -1635,7 +1635,6 @@
           "format": "short",
           "label": "Out (-) / In (+)",
           "logBase": 1,
-          "min": "2",
           "show": true
         },
         {


### PR DESCRIPTION
Outgoing resets and segments are transformed to negative Y. So having a min value of 2 prevents these values from being shown.