### PR TITLE
PMM-13052 Add expression & range for QAN Metrics data source

### DIFF
--- a/dashboards/Query Analytics/pmm-qan.json
+++ b/dashboards/Query Analytics/pmm-qan.json
@@ -112,7 +112,7 @@
             "options": {},
             "targets": [
                 {
-                    "expr": "",
+                    "expr": "{}",
                     "format": "time_series",
                     "intervalFactor": 2,
                     "refId": "A"

--- a/dashboards/Query Analytics/pmm-qan.json
+++ b/dashboards/Query Analytics/pmm-qan.json
@@ -115,6 +115,7 @@
                     "expr": "{}",
                     "format": "time_series",
                     "intervalFactor": 2,
+                    "range": true,
                     "refId": "A"
                 }
             ],


### PR DESCRIPTION
Adding an empty expression and a range parameter allows the QAN panel to be refreshed when time/timezone changes.

FB: https://github.com/Percona-Lab/pmm-submodules/pull/3633