### PR TITLE
Remove duplicated service_name variable in mongodb wired tiger dashboard

### DIFF
--- a/dashboards/MongoDB/MongoDB_WiredTiger_Details.json
+++ b/dashboards/MongoDB/MongoDB_WiredTiger_Details.json
@@ -3943,35 +3943,6 @@
         "useTags": false
       },
       {
-        "allFormat": "glob",
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": "Metrics",
-        "definition": "",
-        "hide": 0,
-        "includeAll": false,
-        "label": "Service Name",
-        "multi": false,
-        "multiFormat": "glob",
-        "name": "service_name",
-        "options": [],
-        "query": {
-          "query": "label_values(mongodb_mongod_storage_engine{cluster=~\"$cluster\",engine=\"inMemory\"}, service_name)",
-          "refId": "Metrics-service_name-Variable-Query"
-        },
-        "refresh": 2,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 5,
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
         "allValue": ".*",
         "current": {
           "selected": false,


### PR DESCRIPTION
Looks like the WiredTiger dashboard has a duplicate service_name variable with no autocomplete. This breaks the dashboard unless I copy the value from the other service_name variable in the select box.

![image](https://github.com/user-attachments/assets/6b2211ab-a959-43fd-b48b-16ceccf276d7)
