### PR TITLE
PMM-7 Refresh connection section

### DIFF
--- a/dashboards/PostgreSQL/PostgreSQL_Instance_Summary.json
+++ b/dashboards/PostgreSQL/PostgreSQL_Instance_Summary.json
@@ -5057,7 +5057,7 @@
           "query": "query_result(pg_postmaster_uptime_seconds{service_name=~\"$service_name\"}/60/60/24)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "/.* ([^\\ ]*) .*/",
         "type": "query"
       },
@@ -5152,7 +5152,7 @@
           "query": "query_result(sum(pg_stat_activity_count{service_name=\"$service_name\"}))",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "/.* ([^\\ ]*) .*/",
         "type": "query"
       },
@@ -5170,7 +5170,7 @@
           "query": "query_result(sum(pg_stat_activity_count{service_name=\"$service_name\",state=\"active\"}))",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "/.* ([^\\ ]*) .*/",
         "type": "query"
       },
@@ -5209,7 +5209,7 @@
         "name": "uptimedecimal",
         "options": [],
         "query": "select round($uptime, 2)",
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "type": "query"
       },


### PR DESCRIPTION
The 'refresh' value controls when the variable is updated: 1=on dashboard load, 2=on time range change. Here, 2 ensures the uptime, connection counts, and active connections variables are refreshed when the time range changes, which is important for accurate reporting. See Grafana docs: https://grafana.com/docs/grafana/latest/variables/variable-types/add-query-variable/#refresh-options

Fixes https://github.com/percona/pmm/issues/4357