### PR TITLE
MongoDB Dashboards improvements

### DIFF
--- a/dashboards/MongoDB/MongoDB_Cluster_Summary.json
+++ b/dashboards/MongoDB/MongoDB_Cluster_Summary.json
@@ -1196,7 +1196,7 @@
           "refId": "A"
         }
       ],
-      "title": "Query execution times",
+      "title": "Operation Latencies",
       "type": "timeseries"
     },
     {

--- a/dashboards/MongoDB/MongoDB_Instances_Overview.json
+++ b/dashboards/MongoDB/MongoDB_Instances_Overview.json
@@ -212,7 +212,7 @@
       "pluginVersion": "8.3.5",
       "targets": [
         {
-          "expr": "count(mongodb_up{service_name=~\"$service_name\"})",
+          "expr": "count(count by(service_name)(mongodb_up{service_name=~\"$service_name\"}))",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,

--- a/dashboards/MongoDB/MongoDB_ReplSet_Summary.json
+++ b/dashboards/MongoDB/MongoDB_ReplSet_Summary.json
@@ -964,10 +964,6 @@
       "type": "gauge"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PA58DA793C7250F1B"
-      },
       "description": "Shows amount of physical IOs (reads and writes) different devices are serving. Spikes in number of IOs served often corresponds to performance problems due to IO subsystem overload.",
       "fieldConfig": {
         "defaults": {
@@ -1056,10 +1052,6 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PA58DA793C7250F1B"
-      },
       "description": "Network traffic refers to the amount of data moving across a network at a given point in time.",
       "fieldConfig": {
         "defaults": {
@@ -1594,7 +1586,7 @@
           "editorMode": "code",
           "expr": "avg by (service_name) (rate(mongodb_ss_metrics_ttl_deletedDocuments{service_name=~\"$service_name\"}[$interval]))",
           "format": "time_series",
-          "hide": true,
+          "hide": false,
           "interval": "$interval",
           "intervalFactor": 1,
           "legendFormat": "ttl_delete - {{service_name}}",
@@ -1691,10 +1683,6 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PA58DA793C7250F1B"
-      },
       "description": "Average latency of operations (classified by read, write, or (other) command)",
       "fieldConfig": {
         "defaults": {
@@ -2352,10 +2340,6 @@
       "id": 1056,
       "panels": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PA58DA793C7250F1B"
-          },
           "description": "MongoDB stores documents in collections. Collections are analogous to tables in relational databases.",
           "fieldConfig": {
             "defaults": {
@@ -2503,10 +2487,6 @@
           "type": "table"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PA58DA793C7250F1B"
-          },
           "description": "MongoDB stores documents in collections. Collections are analogous to tables in relational databases.",
           "fieldConfig": {
             "defaults": {
@@ -2664,10 +2644,6 @@
           "type": "table"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PA58DA793C7250F1B"
-          },
           "description": "MongoDB stores documents in collections. Collections are analogous to tables in relational databases.",
           "fieldConfig": {
             "defaults": {
@@ -2839,10 +2815,6 @@
       "id": 1049,
       "panels": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PA58DA793C7250F1B"
-          },
           "description": "MongoDB replication lag occurs when the secondary node cannot replicate data fast enough to keep up with the rate that data is being written to the primary node. It could be caused by something as simple as network latency, packet loss within your network, or a routing issue.",
           "fieldConfig": {
             "defaults": {

--- a/dashboards/MongoDB/MongoDB_ReplSet_Summary.json
+++ b/dashboards/MongoDB/MongoDB_ReplSet_Summary.json
@@ -1784,7 +1784,7 @@
           "refId": "A"
         }
       ],
-      "title": "Query execution times",
+      "title": "Operation Latencies",
       "type": "timeseries"
     },
     {

--- a/dashboards/MongoDB/MongoDB_ReplSet_Summary.json
+++ b/dashboards/MongoDB/MongoDB_ReplSet_Summary.json
@@ -2317,6 +2317,18 @@
           "range": true,
           "refId": "A",
           "step": 300
+        },
+        {
+          "editorMode": "code",
+          "expr": "avg by() (mongodb_ss_connections{conn_type=~\"current\", service_name=~\"$service_name\"}) - avg by() (mongodb_ss_connections{conn_type=~\"active\", service_name=~\"$service_name\"})",
+          "format": "time_series",
+          "hide": false,
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Idle",
+          "range": true,
+          "refId": "B",
+          "step": 300
         }
       ],
       "title": "Average Connections",

--- a/dashboards/MongoDB/MongoDB_ReplSet_Summary.json
+++ b/dashboards/MongoDB/MongoDB_ReplSet_Summary.json
@@ -199,7 +199,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "11.6.4",
       "targets": [
         {
           "editorMode": "code",
@@ -269,7 +269,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "11.6.4",
       "targets": [
         {
           "editorMode": "code",
@@ -341,7 +341,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "11.6.4",
       "targets": [
         {
           "editorMode": "code",
@@ -412,7 +412,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "11.6.4",
       "targets": [
         {
           "editorMode": "code",
@@ -541,7 +541,7 @@
         "textMode": "value",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "11.6.4",
       "targets": [
         {
           "editorMode": "code",
@@ -743,7 +743,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "11.6.4",
       "targets": [
         {
           "editorMode": "code",
@@ -809,7 +809,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "11.6.4",
       "targets": [
         {
           "editorMode": "code",
@@ -875,7 +875,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "11.6.4",
       "targets": [
         {
           "editorMode": "code",
@@ -939,7 +939,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "11.6.4",
       "targets": [
         {
           "editorMode": "code",
@@ -1016,7 +1016,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "11.6.4",
       "targets": [
         {
           "calculatedInterval": "2m",
@@ -1112,7 +1112,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "11.6.4",
       "targets": [
         {
           "calculatedInterval": "2s",
@@ -1206,7 +1206,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "11.6.4",
       "targets": [
         {
           "calculatedInterval": "10m",
@@ -1278,7 +1278,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "11.6.4",
       "targets": [
         {
           "calculatedInterval": "10m",
@@ -1308,7 +1308,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 9
       },
       "id": 1150,
       "panels": [],
@@ -1428,7 +1428,7 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 20
+        "y": 10
       },
       "id": 1587,
       "options": {
@@ -1447,7 +1447,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "11.6.4",
       "targets": [
         {
           "editorMode": "code",
@@ -1467,7 +1467,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 16
       },
       "id": 1170,
       "panels": [],
@@ -1475,6 +1475,9 @@
       "type": "row"
     },
     {
+      "datasource": {
+        "type": "prometheus"
+      },
       "description": "Ops or Replicated Ops/sec classified by legacy wire protocol type (query, insert, update, delete, getmore). And (from the internal TTL threads) the docs deletes/sec by TTL indexes.",
       "fieldConfig": {
         "defaults": {
@@ -1551,7 +1554,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 27
+        "y": 17
       },
       "id": 15,
       "options": {
@@ -1573,40 +1576,40 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "11.6.4",
       "targets": [
         {
           "editorMode": "code",
-          "expr": "avg by (legacy_op_type) (rate(mongodb_ss_opcountersRepl{service_name=~\"$service_name\", legacy_op_type!~\"(command|query|getmore)\"}[$interval]))",
+          "expr": "avg by (legacy_op_type,service_name) (rate(mongodb_ss_opcountersRepl{service_name=~\"$service_name\", legacy_op_type!~\"(command|query|getmore)\"}[$interval]))",
           "format": "time_series",
-          "hide": false,
+          "hide": true,
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "repl_{{legacy_op_type}}",
+          "legendFormat": "repl_{{legacy_op_type}} - {{service_name}}",
           "range": true,
           "refId": "A",
           "step": 300
         },
         {
           "editorMode": "code",
-          "expr": "avg by () (rate(mongodb_ss_metrics_ttl_deletedDocuments{service_name=~\"$service_name\"}[$interval]))",
+          "expr": "avg by (service_name) (rate(mongodb_ss_metrics_ttl_deletedDocuments{service_name=~\"$service_name\"}[$interval]))",
           "format": "time_series",
-          "hide": false,
+          "hide": true,
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "ttl_delete ",
+          "legendFormat": "ttl_delete - {{service_name}}",
           "range": true,
           "refId": "B",
           "step": 300
         },
         {
           "editorMode": "code",
-          "expr": "avg by (legacy_op_type) (rate(mongodb_ss_opcounters{service_name=~\"$service_name\", legacy_op_type!=\"command\"}[$interval]))",
+          "expr": "avg by (legacy_op_type,service_name) (rate(mongodb_ss_opcounters{service_name=~\"$service_name\", legacy_op_type!=\"command\"}[$interval]))",
           "format": "time_series",
           "hide": false,
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{legacy_op_type}} ",
+          "legendFormat": "{{legacy_op_type}} - {{service_name}}",
           "range": true,
           "refId": "C",
           "step": 300
@@ -1642,7 +1645,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 27
+        "y": 17
       },
       "id": 1024,
       "options": {
@@ -1670,7 +1673,7 @@
         "text": {},
         "valueMode": "color"
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "11.6.4",
       "targets": [
         {
           "editorMode": "code",
@@ -1688,6 +1691,10 @@
       "type": "bargauge"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PA58DA793C7250F1B"
+      },
       "description": "Average latency of operations (classified by read, write, or (other) command)",
       "fieldConfig": {
         "defaults": {
@@ -1751,7 +1758,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 35
+        "y": 25
       },
       "id": 1064,
       "options": {
@@ -1773,7 +1780,7 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "11.6.4",
       "targets": [
         {
           "editorMode": "code",
@@ -1813,7 +1820,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 35
+        "y": 25
       },
       "id": 1028,
       "options": {
@@ -1840,7 +1847,7 @@
         "sizing": "auto",
         "valueMode": "color"
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "11.6.4",
       "targets": [
         {
           "editorMode": "code",
@@ -1920,7 +1927,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 43
+        "y": 33
       },
       "id": 1066,
       "options": {
@@ -1942,7 +1949,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "11.6.4",
       "targets": [
         {
           "editorMode": "code",
@@ -2036,7 +2043,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 43
+        "y": 33
       },
       "id": 1036,
       "options": {
@@ -2058,7 +2065,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "11.6.4",
       "targets": [
         {
           "editorMode": "code",
@@ -2139,7 +2146,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 51
+        "y": 41
       },
       "id": 1067,
       "options": {
@@ -2161,7 +2168,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "11.6.4",
       "targets": [
         {
           "editorMode": "code",
@@ -2270,7 +2277,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 51
+        "y": 41
       },
       "id": 1074,
       "options": {
@@ -2292,7 +2299,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.6.1",
+      "pluginVersion": "11.6.4",
       "targets": [
         {
           "editorMode": "code",
@@ -2340,11 +2347,15 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 59
+        "y": 49
       },
       "id": 1056,
       "panels": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PA58DA793C7250F1B"
+          },
           "description": "MongoDB stores documents in collections. Collections are analogous to tables in relational databases.",
           "fieldConfig": {
             "defaults": {
@@ -2420,7 +2431,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 60
+            "y": 50
           },
           "id": 1045,
           "options": {
@@ -2443,12 +2454,12 @@
               }
             ]
           },
-          "pluginVersion": "11.6.1",
+          "pluginVersion": "11.6.4",
           "targets": [
             {
               "editorMode": "code",
               "exemplar": false,
-              "expr": "max by (environment,cluster,rs_nm,database,service_name) (mongodb_mongod_db_collections_total{cluster=~\"$cluster\",rs_nm=~\"$rs_nm\",db!~\"admin|config\"})",
+              "expr": "max by (environment,cluster,rs_nm,database,service_name) (mongodb_mongod_db_collections_total{cluster=~\"$cluster\",rs_nm=~\"$rs_nm\",db!~\"admin|config\",service_name=~\"$service_name\"})",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -2492,6 +2503,10 @@
           "type": "table"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PA58DA793C7250F1B"
+          },
           "description": "MongoDB stores documents in collections. Collections are analogous to tables in relational databases.",
           "fieldConfig": {
             "defaults": {
@@ -2569,7 +2584,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 68
+            "y": 111
           },
           "id": 1043,
           "options": {
@@ -2592,12 +2607,12 @@
               }
             ]
           },
-          "pluginVersion": "11.6.1",
+          "pluginVersion": "11.6.4",
           "targets": [
             {
               "editorMode": "code",
               "exemplar": false,
-              "expr": "max by (environment,cluster,rs_nm,database,collection,service_name) (mongodb_collstats_storageStats_storageSize{cluster=~\"$cluster\",rs_nm=~\"$rs_nm\",db!~\"admin|config\"})",
+              "expr": "max by (environment,cluster,rs_nm,database,collection,service_name) (mongodb_collstats_storageStats_storageSize{cluster=~\"$cluster\",rs_nm=~\"$rs_nm\",db!~\"admin|config\",service_name=~\"$service_name\"})",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -2649,6 +2664,10 @@
           "type": "table"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PA58DA793C7250F1B"
+          },
           "description": "MongoDB stores documents in collections. Collections are analogous to tables in relational databases.",
           "fieldConfig": {
             "defaults": {
@@ -2726,7 +2745,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 76
+            "y": 119
           },
           "id": 1672,
           "options": {
@@ -2749,12 +2768,12 @@
               }
             ]
           },
-          "pluginVersion": "11.6.1",
+          "pluginVersion": "11.6.4",
           "targets": [
             {
               "editorMode": "code",
               "exemplar": false,
-              "expr": "max by (environment,cluster,rs_nm,database,service_name) (mongodb_mongod_db_collections_total{cluster=~\"$cluster\",rs_nm=~\"$rs_nm\",db!~\"admin|config\"})",
+              "expr": "max by (environment,cluster,rs_nm,database,service_name) (mongodb_mongod_db_collections_total{cluster=~\"$cluster\",rs_nm=~\"$rs_nm\",db!~\"admin|config\",service_name=~\"$service_name\"})",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -2815,11 +2834,15 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 60
+        "y": 50
       },
       "id": 1049,
       "panels": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PA58DA793C7250F1B"
+          },
           "description": "MongoDB replication lag occurs when the secondary node cannot replicate data fast enough to keep up with the rate that data is being written to the primary node. It could be caused by something as simple as network latency, packet loss within your network, or a routing issue.",
           "fieldConfig": {
             "defaults": {
@@ -2833,6 +2856,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 20,
                 "gradientMode": "none",
@@ -2915,7 +2939,7 @@
             "h": 7,
             "w": 8,
             "x": 0,
-            "y": 187
+            "y": 51
           },
           "id": 1038,
           "options": {
@@ -2932,11 +2956,12 @@
               "sortDesc": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "9.2.20",
+          "pluginVersion": "11.6.4",
           "targets": [
             {
               "editorMode": "code",
@@ -2966,6 +2991,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 20,
                 "gradientMode": "none",
@@ -3048,7 +3074,7 @@
             "h": 7,
             "w": 8,
             "x": 8,
-            "y": 187
+            "y": 51
           },
           "id": 1025,
           "options": {
@@ -3065,11 +3091,12 @@
               "sortDesc": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "none"
             }
           },
-          "pluginVersion": "9.2.20",
+          "pluginVersion": "11.6.4",
           "targets": [
             {
               "editorMode": "code",
@@ -3101,6 +3128,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 20,
                 "gradientMode": "none",
@@ -3167,7 +3195,7 @@
             "h": 7,
             "w": 8,
             "x": 16,
-            "y": 187
+            "y": 51
           },
           "id": 1020,
           "options": {
@@ -3184,11 +3212,12 @@
               "sortDesc": true
             },
             "tooltip": {
+              "hideZeros": false,
               "mode": "multi",
               "sort": "desc"
             }
           },
-          "pluginVersion": "9.2.20",
+          "pluginVersion": "11.6.4",
           "targets": [
             {
               "editorMode": "code",
@@ -3273,7 +3302,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 194
+            "y": 97
           },
           "id": 1614,
           "options": {
@@ -3322,7 +3351,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 61
+        "y": 51
       },
       "id": 1403,
       "panels": [
@@ -3517,7 +3546,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 188
+            "y": 52
           },
           "id": 1435,
           "options": {
@@ -3532,7 +3561,7 @@
             },
             "showHeader": true
           },
-          "pluginVersion": "11.1.8",
+          "pluginVersion": "11.6.4",
           "targets": [
             {
               "datasource": "Metrics",
@@ -3675,7 +3704,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 62
+        "y": 52
       },
       "id": 1569,
       "panels": [
@@ -3932,7 +3961,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 189
+            "y": 53
           },
           "id": 337,
           "options": {
@@ -4008,7 +4037,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 63
+        "y": 53
       },
       "id": 1571,
       "panels": [
@@ -4218,7 +4247,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 189
+            "y": 54
           },
           "id": 339,
           "options": {
@@ -4288,7 +4317,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 64
+        "y": 54
       },
       "id": 1585,
       "panels": [
@@ -4437,7 +4466,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 190
+            "y": 55
           },
           "id": 341,
           "links": [
@@ -4540,7 +4569,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 65
+        "y": 55
       },
       "id": 1583,
       "panels": [
@@ -4620,7 +4649,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 191
+            "y": 56
           },
           "id": 343,
           "options": {
@@ -4808,11 +4837,8 @@
           "value": "$__all"
         },
         "definition": "label_values(mongodb_mongod_replset_my_state{environment=~\"$environment\",cluster=~\"$cluster\",set=~\"$rs_nm\"}, service_name)",
-        "hide": 0,
         "includeAll": true,
         "label": "MongoDB Node",
-        "multi": false,
-        "multiFormat": "glob",
         "name": "service_name",
         "options": [],
         "query": {
@@ -4826,7 +4852,6 @@
       },
       {
         "current": {
-          "selected": true,
           "text": [
             "All"
           ],
@@ -4852,7 +4877,6 @@
       },
       {
         "current": {
-          "selected": true,
           "text": [
             "All"
           ],
@@ -4876,14 +4900,12 @@
       },
       {
         "current": {
-          "selected": true,
-          "text":"",
-          "value":""
+          "text": "",
+          "value": ""
         },
         "definition": "query_result(mongodb_mongod_replset_my_state{environment=~\"$environment\",cluster=~\"$cluster\",set=~\"$rs_nm\"}==1)",
         "hide": 2,
         "includeAll": false,
-        "multi": false,
         "name": "primary",
         "options": [],
         "query": {

--- a/dashboards/MongoDB/MongoDB_Router_Summary.json
+++ b/dashboards/MongoDB/MongoDB_Router_Summary.json
@@ -779,7 +779,7 @@
           "datasourceErrors": {},
           "errors": {},
           "exemplar": true,
-          "expr": "avg by (node_name)  (time() - container_start_time_seconds{node_name=~\"$node_name\",id=~\"/kubepods.*\",container!~\"POD|pmm-client|\"}) or avg by (node_name) ((node_time_seconds{node_name=~\"$node_name\"} - node_boot_time_seconds{node_name=~\"$node_name\"}) or (time() - node_boot_time_seconds{node_name=~\"$node_name\"}))",
+          "expr": "mongodb_ss_uptime{node_name=~\"$node_name\"}",
           "format": "time_series",
           "hide": false,
           "interval": "5m",

--- a/dashboards/MongoDB/MongoDB_Router_Summary.json
+++ b/dashboards/MongoDB/MongoDB_Router_Summary.json
@@ -1308,7 +1308,7 @@
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "Query execution times",
+      "title": "Operation Latencies",
       "tooltip": {
         "shared": true,
         "sort": 2,

--- a/dashboards/MongoDB/MongoDB_Router_Summary.json
+++ b/dashboards/MongoDB/MongoDB_Router_Summary.json
@@ -1213,6 +1213,18 @@
           "range": true,
           "refId": "A",
           "step": 300
+        },
+        {
+          "editorMode": "code",
+          "expr": "avg by(service_name)(mongodb_ss_connections{conn_type=\"current\", service_name=~\"$service_name\"}) - avg by(service_name)(mongodb_ss_connections{conn_type=\"active\", service_name=~\"$service_name\"})",
+          "format": "time_series",
+          "hide": false,
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": " Idle - {{ service_name }}",
+          "range": true,
+          "refId": "B",
+          "step": 300
         }
       ],
       "thresholds": [],


### PR DESCRIPTION
Resolves following issues:
- PMM-14107 - Rename Query Execution Times Panel to Latency
- PMM-14265 - Wrong uptime displayed for mongos nodes
- PMM-14022 - PMM shows duplicated service counts in dashboard and instance alerts
- PMM-14108 - Extend connection panel with idle connections
- PMM-14106 - Add node filter for Command Operations

FB: https://github.com/Percona-Lab/pmm-submodules/pull/4033