### PR TITLE
PMM-7 Update CODEOWNERS for dashboards directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 *            @percona/pmm-review-fe
-dashboards/  @YashSartanpara1
+dashboards/  @nailya @YashSartanpara1


### PR DESCRIPTION
We want to slightly change the workflow in this repository so that a PR can be merged only if two code owners have approved the PR.

To that end, we are adding one more code owner from the QA team. The change in settings will follow soon after.